### PR TITLE
Add exception handling to avoid crash when comparing types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.0.1
 * Restructure tests directory
+* Fix comparison check to not crash when comparing a dict to a non-dict (issue #6)
 * Enable integration tests within collection
 * Fix linting errors
 * Improve type documentation for module parameters

--- a/plugins/module_utils/network/meraki/meraki.py
+++ b/plugins/module_utils/network/meraki/meraki.py
@@ -239,14 +239,17 @@ class MerakiModule(object):
                     # self.fail_json(msg="List doesn't match", a=a, b=b)
                     return True
         elif isinstance(original, dict):
-            for k, v in proposed.items():
-                if k not in self.ignored_keys:
-                    if k in original:
-                        if self.is_update_required(original[k], proposed[k]):
+            try:
+                for k, v in proposed.items():
+                    if k not in self.ignored_keys:
+                        if k in original:
+                            if self.is_update_required(original[k], proposed[k]):
+                                return True
+                        else:
+                            # self.fail_json(msg="Key not in original", k=k)
                             return True
-                    else:
-                        # self.fail_json(msg="Key not in original", k=k)
-                        return True
+            except AttributeError:
+                return True
         else:
             if original != proposed:
                 # self.fail_json(msg="Fallback", original=original, proposed=proposed)


### PR DESCRIPTION
`is_update_required()` didn't handle exceptions if the types were different. This used to be handled by the type comparison, but since that is removed, this is needed.

This pull request fixes the corner case where the proposed object isn't a dict so `.items()` would crash. The `AttributeError` exception is now handled.

Fixes #6

- [x] meraki_admin.py
- [x] meraki_config_template.py
- [x] meraki_content_filtering.py
- [x] meraki_device.py
- [x] meraki_firewalled_services.py
- [x] meraki_malware.py
- [x] meraki_mr_l3_firewall.py
- [x] meraki_mx_l3_firewall.py
- [x] meraki_mx_l7_firewall.py
- [x] meraki_nat.py
- [x] meraki_network.py
- [x] meraki_organization.py
- [x] meraki_snmp.py
- [x] meraki_ssid.py
- [x] meraki_static_route.py
- [x] meraki_switchport.py
- [x] meraki_syslog.py
- [x] meraki_vlan.py
- [x] meraki_webhook.py