### PR TITLE
Content filtering integration test deletes network after completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix crash when unbinding a template in check mode with net_id (issue #19)
 * Improve type documentation for module parameters
 * Improve HTTP error reporting for 400 errors
+* Content filtering integration test deletes network after completion
 
 ## v0.0.0
 * Initial commit of collection into Ansible Galaxy

--- a/tests/integration/targets/meraki_content_filtering/tasks/main.yml
+++ b/tests/integration/targets/meraki_content_filtering/tasks/main.yml
@@ -245,3 +245,11 @@
           -
         blocked_urls:
           -
+
+    - name: Delete network
+      meraki_network:
+        auth_key: '{{auth_key}}'
+        org_name: '{{test_org_name}}'
+        net_name: '{{test_net_name}}'
+        state: absent
+


### PR DESCRIPTION
Integration tests for `meraki_content_filtering` now deletes the network upon completion, success or failure.

Fixes #5 and depends on https://github.com/CiscoDevNet/ansible-meraki/pull/7