### PR TITLE
Fix 400 error handling to remove crashes

### DIFF
--- a/plugins/module_utils/network/meraki/meraki.py
+++ b/plugins/module_utils/network/meraki/meraki.py
@@ -89,7 +89,7 @@ def _error_report(function):
                     raise InternalErrorException(
                         "Internal server error 502, retry {0}".format(self.retry))
                 elif self.status >= 400:
-                    raise HTTPError("HTTP error {0} - {1}".format(self.status, response))
+                    raise HTTPError("")
                 self.retry = 0  # Needs to reset in case of future retries
                 return response
             except RateLimitException as e:
@@ -113,8 +113,11 @@ def _error_report(function):
                 if self.retry_time > self.params['internal_error_retry_time']:
                     raise InternalErrorException(e)
             except HTTPError as e:
-                raise HTTPError(e)
-    return inner
+                self.fail_json(msg="HTTP error {0} - {1}".format(self.status, self.url))
+    try:
+        return inner
+    except HTTPError:
+            self.fail_json("Something went wrong")
 
 
 class MerakiModule(object):

--- a/tests/integration/targets/meraki_admin/tasks/main.yml
+++ b/tests/integration/targets/meraki_admin/tasks/main.yml
@@ -143,7 +143,7 @@
   - assert:
       that:
         - '"400" in create_tags_invalid.msg'
-        # - '"must contain only valid tags" in create_tags_invalid.msg'
+        - '"Invalid permission type" in create_tags_invalid.msg'
 
   - name: Create administrator with invalid tag permission
     meraki_admin:
@@ -163,7 +163,7 @@
   - assert:
       that:
         - '"400" in create_tags_invalid_permission.msg'
-        # - '"Invalid permission type" in create_tags_invalid_permission.msg'
+        - '"Invalid permission type" in create_tags_invalid_permission.msg'
 
   - name: Make sure TestNet and TestNet2 are created
     meraki_network:

--- a/tests/integration/targets/meraki_syslog/tasks/main.yml
+++ b/tests/integration/targets/meraki_syslog/tasks/main.yml
@@ -128,8 +128,8 @@
     register: invalid_role
     ignore_errors: yes
 
-  # - debug:
-  #     msg: '{{invalid_role.body.errors.0}}'
+  - debug:
+      msg: '{{invalid_role.msg}}'
 
   - assert:
       that:


### PR DESCRIPTION
400 series errors may not pass the right information to the output so it would crash. This reworks the exception handling to improve output and reduce crashes.

- [x] meraki_admin.py
- [ ] meraki_config_template.py
- [ ] meraki_content_filtering.py
- [x] meraki_device.py
- [x] meraki_firewalled_services.py
- [x] meraki_malware.py
- [x] meraki_mr_l3_firewall.py
- [x] meraki_mx_l3_firewall.py
- [x] meraki_mx_l7_firewall.py
- [x] meraki_nat.py
- [x] meraki_network.py
- [x] meraki_organization.py
- [x] meraki_snmp.py
- [x] meraki_ssid.py
- [x] meraki_static_route.py
- [x] meraki_switchport.py
- [x] meraki_syslog.py
- [x] meraki_vlan.py
- [x] meraki_webhook.py