### PR TITLE
Fix crash when unbinding template with net_id in check mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Restructure tests directory
 * Enable integration tests within collection
 * Fix linting errors
+* Fix crash when unbinding a template in check mode with net_id (issue #19)
 * Improve type documentation for module parameters
 
 ## v0.0.0

--- a/plugins/modules/meraki_config_template.py
+++ b/plugins/modules/meraki_config_template.py
@@ -293,6 +293,8 @@ def main():
             else:
                 meraki.fail_json(msg="No template named {0} found.".format(meraki.params['config_template']))
         else:  # Unbind template
+            if nets is None:
+                nets = meraki.get_nets(org_id=org_id)
             if meraki.check_mode is True:
                 meraki.result['data'] = {}
                 if is_template_valid(meraki, nets, template_id) is True:
@@ -303,8 +305,6 @@ def main():
             template_id = get_template_id(meraki,
                                           meraki.params['config_template'],
                                           get_config_templates(meraki, org_id))
-            if nets is None:
-                nets = meraki.get_nets(org_id=org_id)
             if is_network_bound(meraki, nets, net_id, template_id) is True:
                 if meraki.check_mode is True:
                     meraki.result['data'] = {}

--- a/tests/integration/targets/meraki_config_template/tasks/main.yml
+++ b/tests/integration/targets/meraki_config_template/tasks/main.yml
@@ -164,27 +164,27 @@
         unbind_id.changed == True
 
   # This is disabled by default since they can't be created via API
-  - name: Delete sacrificial template with check mode
-    meraki_config_template:
-      auth_key: '{{auth_key}}'
-      state: absent
-      org_name: '{{test_org_name}}'
-      config_template: sacrificial_template
-    check_mode: yes
-    register: delete_template_check
+  # - name: Delete sacrificial template with check mode
+  #   meraki_config_template:
+  #     auth_key: '{{auth_key}}'
+  #     state: absent
+  #     org_name: '{{test_org_name}}'
+  #     config_template: sacrificial_template
+  #   check_mode: yes
+  #   register: delete_template_check
 
   # This is disabled by default since they can't be created via API
-  - name: Delete sacrificial template
-    meraki_config_template:
-      auth_key: '{{auth_key}}'
-      state: absent
-      org_name: '{{test_org_name}}'
-      config_template: sacrificial_template
-      output_level: debug
-    register: delete_template
+  # - name: Delete sacrificial template
+  #   meraki_config_template:
+  #     auth_key: '{{auth_key}}'
+  #     state: absent
+  #     org_name: '{{test_org_name}}'
+  #     config_template: sacrificial_template
+  #     output_level: debug
+  #   register: delete_template
 
-  - debug:
-      var: delete_template
+  # - debug:
+  #     var: delete_template
 
   always:
   - name: Delete network


### PR DESCRIPTION
`nets` was created too late so the module was calling it before it was set to something valid. This PR fixes this crash.

Fixes #19 