### PR TITLE
meraki_firewalled_services recognizes net_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Fix crash when unbinding a template in check mode with net_id (issue #19)
 * Improve type documentation for module parameters
 * Improve HTTP error reporting for 400 errors
+* meraki_firewalled_services recognizes net_id
 
 ## v0.0.0
 * Initial commit of collection into Ansible Galaxy

--- a/plugins/modules/meraki_firewalled_services.py
+++ b/plugins/modules/meraki_firewalled_services.py
@@ -184,7 +184,7 @@ def main():
     org_id = meraki.params['org_id']
     if not org_id:
         org_id = meraki.get_org_id(meraki.params['org_name'])
-    net_id = None
+    net_id = meraki.params['net_id']
     if net_id is None:
         nets = meraki.get_nets(org_id=org_id)
         net_id = meraki.get_net_id(org_id, meraki.params['net_name'], data=nets)

--- a/tests/integration/targets/meraki_firewalled_services/tasks/tests.yml
+++ b/tests/integration/targets/meraki_firewalled_services/tasks/tests.yml
@@ -153,6 +153,22 @@
       that:
         - 'access_error.msg == "allowed_ips is only allowed when access is restricted."'
 
+  - name: Query appliance servicesn with net_id
+    meraki_firewalled_services:
+      auth_key: '{{ auth_key }}'
+      state: query
+      org_name: '{{test_org_name}}'
+      net_id: '{{net_id}}'
+    register: query_appliance_id
+
+  - debug:
+      var: query_appliance_id
+
+  - assert:
+      that:
+        - <query_appliance_id></query_appliance_id>.data is defined
+
+
   - name: Query appliance services
     meraki_firewalled_services:
       auth_key: '{{ auth_key }}'

--- a/tests/integration/targets/meraki_firewalled_services/tasks/tests.yml
+++ b/tests/integration/targets/meraki_firewalled_services/tasks/tests.yml
@@ -14,7 +14,7 @@
     register: create
 
   - set_fact:
-      net_id: create.data.id
+      net_id: '{{create.data.id}}'
 
   - name: Set icmp service to blocked with check mode
     meraki_firewalled_services:
@@ -153,7 +153,7 @@
       that:
         - 'access_error.msg == "allowed_ips is only allowed when access is restricted."'
 
-  - name: Query appliance servicesn with net_id
+  - name: Query appliance services with net_id
     meraki_firewalled_services:
       auth_key: '{{ auth_key }}'
       state: query
@@ -166,7 +166,7 @@
 
   - assert:
       that:
-        - <query_appliance_id></query_appliance_id>.data is defined
+        - query_appliance_id.data is defined
 
 
   - name: Query appliance services


### PR DESCRIPTION
The module didn't look at net_id. This commit fixes that and adds an
integration test.

Fixes #22 