### PR TITLE
Remove unused import statements and variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## v0.0.1
+* Fix most linting errors (issue #13)
 * Restructure tests directory
 * Fix comparison check to not crash when comparing a dict to a non-dict (issue #6)
 * Enable integration tests within collection

--- a/plugins/modules/meraki_admin.py
+++ b/plugins/modules/meraki_admin.py
@@ -248,9 +248,7 @@ data:
 '''
 
 import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible.module_utils.common.dict_transformations import recursive_diff
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 
@@ -393,15 +391,6 @@ def main():
                          org_id=dict(type='str'),
                          )
 
-    # seed the result dict in the object
-    # we primarily care about changed and state
-    # change is if this module effectively modified the target
-    # state will include any data that you want your module to pass back
-    # for consumption, for example, in a subsequent task
-    result = dict(
-        changed=False,
-    )
-
     # the AnsibleModule object will be our abstraction working with Ansible
     # this includes instantiation, a couple of common attr would be the
     # args/params passed to the execution, as well as if the module
@@ -432,8 +421,6 @@ def main():
         meraki.params['auth_key'] = os.environ['MERAKI_KEY']
     except KeyError:
         pass
-
-    payload = None
 
     # if the user is working with this module in only check mode we do not
     # want to make any changes to the environment, just return the current

--- a/plugins/modules/meraki_config_template.py
+++ b/plugins/modules/meraki_config_template.py
@@ -117,10 +117,7 @@ data:
           sample: YourTemplate
 '''
 
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 
 
@@ -195,14 +192,6 @@ def main():
                          auto_bind=dict(type='bool'),
                          )
 
-    # seed the result dict in the object
-    # we primarily care about changed and state
-    # change is if this module effectively modified the target
-    # state will include any data that you want your module to pass back
-    # for consumption, for example, in a subsequent task
-    result = dict(
-        changed=False,
-    )
     # the AnsibleModule object will be our abstraction working with Ansible
     # this includes instantiation, a couple of common attr would be the
     # args/params passed to the execution, as well as if the module

--- a/plugins/modules/meraki_content_filtering.py
+++ b/plugins/modules/meraki_content_filtering.py
@@ -113,10 +113,7 @@ data:
         sample: N_12345
 '''
 
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible.module_utils.common.dict_transformations import recursive_diff
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 

--- a/plugins/modules/meraki_device.py
+++ b/plugins/modules/meraki_device.py
@@ -205,9 +205,7 @@ response:
     returned: info
 '''
 
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 
 
@@ -252,14 +250,6 @@ def main():
                          note=dict(type='str'),
                          )
 
-    # seed the result dict in the object
-    # we primarily care about changed and state
-    # change is if this module effectively modified the target
-    # state will include any data that you want your module to pass back
-    # for consumption, for example, in a subsequent task
-    result = dict(
-        changed=False,
-    )
     # the AnsibleModule object will be our abstraction working with Ansible
     # this includes instantiation, a couple of common attr would be the
     # args/params passed to the execution, as well as if the module

--- a/plugins/modules/meraki_firewalled_services.py
+++ b/plugins/modules/meraki_firewalled_services.py
@@ -135,10 +135,7 @@ data:
         sample: 192.0.1.0
 '''
 
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible.module_utils.common.dict_transformations import recursive_diff
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 

--- a/plugins/modules/meraki_malware.py
+++ b/plugins/modules/meraki_malware.py
@@ -162,9 +162,7 @@ data:
                     sample: Corporate HQ
 '''
 
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible.module_utils.common.dict_transformations import recursive_diff
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 
@@ -190,14 +188,6 @@ def main():
                          allowed_files=dict(type='list', default=None, elements='dict', options=files_arg_spec),
                          )
 
-    # seed the result dict in the object
-    # we primarily care about changed and state
-    # change is if this module effectively modified the target
-    # state will include any data that you want your module to pass back
-    # for consumption, for example, in a subsequent task
-    result = dict(
-        changed=False,
-    )
     # the AnsibleModule object will be our abstraction working with Ansible
     # this includes instantiation, a couple of common attr would be the
     # args/params passed to the execution, as well as if the module

--- a/plugins/modules/meraki_mr_l3_firewall.py
+++ b/plugins/modules/meraki_mr_l3_firewall.py
@@ -125,10 +125,7 @@ RETURN = r'''
 
 '''
 
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 
 
@@ -189,14 +186,6 @@ def main():
                          allow_lan_access=dict(type='bool', default=True),
                          )
 
-    # seed the result dict in the object
-    # we primarily care about changed and state
-    # change is if this module effectively modified the target
-    # state will include any data that you want your module to pass back
-    # for consumption, for example, in a subsequent task
-    result = dict(
-        changed=False,
-    )
     # the AnsibleModule object will be our abstraction working with Ansible
     # this includes instantiation, a couple of common attr would be the
     # args/params passed to the execution, as well as if the module

--- a/plugins/modules/meraki_mx_l3_firewall.py
+++ b/plugins/modules/meraki_mx_l3_firewall.py
@@ -187,10 +187,7 @@ data:
             sample: true
 '''
 
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 
 
@@ -243,14 +240,6 @@ def main():
                          syslog_default_rule=dict(type='bool'),
                          )
 
-    # seed the result dict in the object
-    # we primarily care about changed and state
-    # change is if this module effectively modified the target
-    # state will include any data that you want your module to pass back
-    # for consumption, for example, in a subsequent task
-    result = dict(
-        changed=False,
-    )
     # the AnsibleModule object will be our abstraction working with Ansible
     # this includes instantiation, a couple of common attr would be the
     # args/params passed to the execution, as well as if the module

--- a/plugins/modules/meraki_mx_l7_firewall.py
+++ b/plugins/modules/meraki_mx_l7_firewall.py
@@ -249,8 +249,7 @@ data:
 '''
 
 import copy
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible.module_utils.common.dict_transformations import recursive_diff
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 
@@ -374,14 +373,6 @@ def main():
                          categories=dict(type='bool'),
                          )
 
-    # seed the result dict in the object
-    # we primarily care about changed and state
-    # change is if this module effectively modified the target
-    # state will include any data that you want your module to pass back
-    # for consumption, for example, in a subsequent task
-    result = dict(
-        changed=False,
-    )
     # the AnsibleModule object will be our abstraction working with Ansible
     # this includes instantiation, a couple of common attr would be the
     # args/params passed to the execution, as well as if the module

--- a/plugins/modules/meraki_nat.py
+++ b/plugins/modules/meraki_nat.py
@@ -407,10 +407,7 @@ data:
                             example: internet1
 '''
 
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible.module_utils.common.dict_transformations import recursive_diff
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 

--- a/plugins/modules/meraki_network.py
+++ b/plugins/modules/meraki_network.py
@@ -181,10 +181,7 @@ data:
         sample: true
 '''
 
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 
 

--- a/plugins/modules/meraki_organization.py
+++ b/plugins/modules/meraki_organization.py
@@ -113,10 +113,7 @@ data:
 
 '''
 
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 
 
@@ -140,14 +137,6 @@ def main():
                          org_id=dict(type='str', aliases=['id']),
                          )
 
-    # seed the result dict in the object
-    # we primarily care about changed and state
-    # change is if this module effectively modified the target
-    # state will include any data that you want your module to pass back
-    # for consumption, for example, in a subsequent task
-    result = dict(
-        changed=False,
-    )
     # the AnsibleModule object will be our abstraction working with Ansible
     # this includes instantiation, a couple of common attr would be the
     # args/params passed to the execution, as well as if the module

--- a/plugins/modules/meraki_snmp.py
+++ b/plugins/modules/meraki_snmp.py
@@ -234,10 +234,7 @@ data:
                     returned: success, when network specified
 '''
 
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible.module_utils.common.dict_transformations import recursive_diff, snake_dict_to_camel_dict
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 
@@ -328,14 +325,6 @@ def main():
                          net_id=dict(type='str'),
                          )
 
-    # seed the result dict in the object
-    # we primarily care about changed and state
-    # change is if this module effectively modified the target
-    # state will include any data that you want your module to pass back
-    # for consumption, for example, in a subsequent task
-    result = dict(
-        changed=False,
-    )
     # the AnsibleModule object will be our abstraction working with Ansible
     # this includes instantiation, a couple of common attr would be the
     # args/params passed to the execution, as well as if the module

--- a/plugins/modules/meraki_ssid.py
+++ b/plugins/modules/meraki_ssid.py
@@ -343,10 +343,7 @@ data:
             sample: 0
 '''
 
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 
 

--- a/plugins/modules/meraki_static_route.py
+++ b/plugins/modules/meraki_static_route.py
@@ -218,10 +218,7 @@ data:
               sample: JimLaptop
 '''
 
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 
 

--- a/plugins/modules/meraki_switchport.py
+++ b/plugins/modules/meraki_switchport.py
@@ -251,10 +251,7 @@ data:
             sample: "Auto negotiate"
 '''
 
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 
 param_map = {'access_policy_number': 'accessPolicyNumber',

--- a/plugins/modules/meraki_syslog.py
+++ b/plugins/modules/meraki_syslog.py
@@ -140,10 +140,7 @@ data:
         sample: "Wireless event log, URLs"
 '''
 
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils.urls import fetch_url
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible.module_utils.common.dict_transformations import recursive_diff
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 

--- a/plugins/modules/meraki_vlan.py
+++ b/plugins/modules/meraki_vlan.py
@@ -291,10 +291,10 @@ response:
           sample: 192.0.1.2
 '''
 
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.dict_transformations import recursive_diff
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
+import json
 
 
 def fixed_ip_factory(meraki, data):
@@ -350,14 +350,6 @@ def main():
                          dns_nameservers=dict(type='str'),
                          )
 
-    # seed the result dict in the object
-    # we primarily care about changed and state
-    # change is if this module effectively modified the target
-    # state will include any data that you want your module to pass back
-    # for consumption, for example, in a subsequent task
-    result = dict(
-        changed=False,
-    )
     # the AnsibleModule object will be our abstraction working with Ansible
     # this includes instantiation, a couple of common attr would be the
     # args/params passed to the execution, as well as if the module

--- a/plugins/modules/meraki_webhook.py
+++ b/plugins/modules/meraki_webhook.py
@@ -165,9 +165,7 @@ data:
           sample: enqueued
 '''
 
-import os
-from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule, json
 from ansible.module_utils.common.dict_transformations import recursive_diff
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
 
@@ -202,14 +200,6 @@ def main():
                          test_id=dict(type='str'),
                          )
 
-    # seed the result dict in the object
-    # we primarily care about changed and state
-    # change is if this module effectively modified the target
-    # state will include any data that you want your module to pass back
-    # for consumption, for example, in a subsequent task
-    result = dict(
-        changed=False,
-    )
     # the AnsibleModule object will be our abstraction working with Ansible
     # this includes instantiation, a couple of common attr would be the
     # args/params passed to the execution, as well as if the module


### PR DESCRIPTION
Remove all unused import statements and variables based on linting information from Ansible Galaxy. Probably more to come though.

Fixes #13 