### PR TITLE
Change if condition so resetting firewall rules works

### DIFF
--- a/plugins/modules/meraki_mx_l3_firewall.py
+++ b/plugins/modules/meraki_mx_l3_firewall.py
@@ -289,7 +289,7 @@ def main():
     elif meraki.params['state'] == 'present':
         rules = get_rules(meraki, net_id)
         path = meraki.construct_path('get_all', net_id=net_id)
-        if meraki.params['rules']:
+        if meraki.params['rules'] is not None:
             payload = assemble_payload(meraki)
         else:
             payload = dict()


### PR DESCRIPTION
The firewall rules didn't have the ability to be reset to a fresh start. It appears a blank list wasn't picked up by an if condition. This PR fixes the problem.

Fixes #12