### PR TITLE
Clean up sanity errors

### DIFF
--- a/plugins/module_utils/network/meraki/meraki.py
+++ b/plugins/module_utils/network/meraki/meraki.py
@@ -1,33 +1,10 @@
 # -*- coding: utf-8 -*-
 
-# This code is part of Ansible, but is an independent component
+# Copyright: (c) 2018, Kevin Breit (@kbreit) <kevin.breit@kevinbreit.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This particular file snippet, and this file snippet only, is BSD licensed.
-# Modules you write using this snippet, which is embedded dynamically by Ansible
-# still belong to the author of the module, and may assign their own license
-# to the complete work.
-
-# Copyright: (c) 2018, Kevin Breit <kevin.breit@kevinbreit.net>
-# All rights reserved.
-
-# Redistribution and use in source and binary forms, with or without modification,
-# are permitted provided that the following conditions are met:
-#
-#    * Redistributions of source code must retain the above copyright
-#      notice, this list of conditions and the following disclaimer.
-#    * Redistributions in binary form must reproduce the above copyright notice,
-#      this list of conditions and the following disclaimer in the documentation
-#      and/or other materials provided with the distribution.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
-# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 import time
 import os
@@ -123,7 +100,7 @@ def _error_report(function):
     try:
         return inner
     except HTTPError:
-            self.fail_json("Something went wrong")
+        pass
 
 
 class MerakiModule(object):

--- a/plugins/modules/meraki_admin.py
+++ b/plugins/modules/meraki_admin.py
@@ -43,6 +43,7 @@ options:
         - Tags the administrator has privileges on.
         - When creating a new administrator, C(org_name), C(network), or C(tags) must be specified.
         - If C(none) is specified, C(network) or C(tags) must be specified.
+        type: list
         suboptions:
             tag:
                 description:
@@ -56,6 +57,7 @@ options:
         description:
         - List of networks the administrator has privileges on.
         - When creating a new administrator, C(org_name), C(network), or C(tags) must be specified.
+        type: list
         suboptions:
             id:
                 description:
@@ -307,7 +309,6 @@ def delete_admin(meraki, org_id, admin_id):
 
 
 def network_factory(meraki, networks, nets):
-    networks = json.loads(networks)
     networks_new = []
     for n in networks:
         networks_new.append({'id': meraki.get_net_id(org_name=meraki.params['org_name'],
@@ -328,7 +329,7 @@ def create_admin(meraki, org_id, name, email):
     if meraki.params['org_access'] is not None:
         payload['orgAccess'] = meraki.params['org_access']
     if meraki.params['tags'] is not None:
-        payload['tags'] = json.loads(meraki.params['tags'])
+        payload['tags'] = meraki.params['tags']
     if meraki.params['networks'] is not None:
         nets = meraki.get_nets(org_id=org_id)
         networks = network_factory(meraki, meraki.params['networks'], nets)
@@ -380,13 +381,22 @@ def create_admin(meraki, org_id, name, email):
 def main():
     # define the available arguments/parameters that a user can pass to
     # the module
+
+    network_arg_spec = dict(id=dict(type='str'),
+                            access=dict(type='str'),
+                            )
+
+    tag_arg_spec = dict(tag=dict(type='str'),
+                        access=dict(type='str'),
+                        )
+
     argument_spec = meraki_argument_spec()
     argument_spec.update(state=dict(type='str', choices=['present', 'query', 'absent'], required=True),
                          name=dict(type='str'),
                          email=dict(type='str'),
                          org_access=dict(type='str', aliases=['orgAccess'], choices=['full', 'read-only', 'none']),
-                         tags=dict(type='json'),
-                         networks=dict(type='json'),
+                         tags=dict(type='list', element='dict', options=tag_arg_spec),
+                         networks=dict(type='list', element='dict', options=network_arg_spec),
                          org_name=dict(type='str', aliases=['organization']),
                          org_id=dict(type='str'),
                          )

--- a/tests/integration/targets/meraki_admin/tasks/main.yml
+++ b/tests/integration/targets/meraki_admin/tasks/main.yml
@@ -88,7 +88,8 @@
       email: '{{email_prefix}}+johndoe@{{email_domain}}'
       orgAccess: none
       tags:
-        - { "tag": "production", "access": "read-only" }
+        - tag: production
+          access: read-only
         - tag: beta
           access: full
     delegate_to: localhost
@@ -113,7 +114,8 @@
       email: '{{email_prefix}}+johndoe@{{email_domain}}'
       orgAccess: none
       tags:
-        - { "tag": "production", "access": "read-only" }
+        - tag: production
+          access: read-only
         - tag: beta
           access: full
     delegate_to: localhost
@@ -134,8 +136,10 @@
       email: '{{email_prefix}}+jakedoe@{{email_domain}}'
       orgAccess: none
       tags:
-        - { "tag": "production", "access": "read-only" }
-        - { "tag": "alpha", "access": "invalid" }
+        - tag: production
+          access: read-only
+        - tag: alpha
+          access: invalid
     delegate_to: localhost
     register: create_tags_invalid
     ignore_errors: yes
@@ -154,8 +158,10 @@
       email: '{{email_prefix}}+jakedoe@{{email_domain}}'
       orgAccess: none
       tags:
-        - { "tag": "production", "access": "read-only" }
-        - { "tag": "beta", "access": "invalid" }
+        - tag: production
+          access: read-only
+        - tag: beta
+          access: invalid
     delegate_to: localhost
     register: create_tags_invalid_permission
     ignore_errors: yes
@@ -185,8 +191,10 @@
       email: '{{email_prefix}}+jimdoe@{{email_domain}}'
       orgAccess: none
       networks:
-        - { "network": "TestNet", "access": "read-only" }
-        - { "network": "TestNet2", "access": "full" }
+        - network: TestNet
+          access: read-only
+        - network: TestNet2
+          access: full
     delegate_to: localhost
     register: create_network_check
     check_mode: yes
@@ -206,8 +214,10 @@
       email: '{{email_prefix}}+jimdoe@{{email_domain}}'
       orgAccess: none
       networks:
-        - { "network": "TestNet", "access": "read-only" }
-        - { "network": "TestNet2", "access": "full" }
+        - network: TestNet
+          access: read-only
+        - network: TestNet2
+          access: full
     delegate_to: localhost
     register: create_network
 
@@ -226,7 +236,8 @@
       email: '{{email_prefix}}+jimdoe@{{email_domain}}'
       orgAccess: none
       networks:
-        - { "network": "TestNet", "access": "full" }
+        - network: TestNet
+          access: full
     delegate_to: localhost
     register: update_network_check
     check_mode: yes
@@ -249,7 +260,8 @@
       email: '{{email_prefix}}+jimdoe@{{email_domain}}'
       orgAccess: none
       networks:
-        - { "network": "TestNet", "access": "full" }
+        - network: TestNet
+          access: full
     delegate_to: localhost
     register: update_network
 
@@ -268,7 +280,8 @@
       email: '{{email_prefix}}+jimdoe@{{email_domain}}'
       orgAccess: none
       networks:
-        - { "network": "TestNet", "access": "full" }
+        - network: TestNet
+          access: full
     delegate_to: localhost
     register: update_network_idempotent_check
     check_mode: yes
@@ -289,7 +302,8 @@
       email: '{{email_prefix}}+jimdoe@{{email_domain}}'
       orgAccess: none
       networks:
-        - { "network": "TestNet", "access": "full" }
+        - network: TestNet
+          access: full
     delegate_to: localhost
     register: update_network_idempotent
 
@@ -307,7 +321,8 @@
       email: '{{email_prefix}}+John@{{email_domain}}'
       orgAccess: none
       networks:
-        - { "network": "readnet", "access": "read-only" }
+        - network: TestNetFake
+          access: read-only
     delegate_to: localhost
     register: create_network_invalid
     ignore_errors: yes
@@ -324,6 +339,9 @@
       org_name: '{{test_org_name}}'
     delegate_to: localhost
     register: query_all
+
+  - debug:
+      var: query_all
 
   - assert:
       that:

--- a/tests/integration/targets/meraki_content_filtering/tasks/main.yml
+++ b/tests/integration/targets/meraki_content_filtering/tasks/main.yml
@@ -252,4 +252,3 @@
         org_name: '{{test_org_name}}'
         net_name: '{{test_net_name}}'
         state: absent
-


### PR DESCRIPTION
`ansible-test sanity` was throwing some errors. This PR gets rid of the errors. It also modifies meraki_admin spec to no longer use JSON.

Fixes #29