### PR TITLE
Create new diff method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Changelog
 
+## v0.1.0
+
+### Enhancements
+* diff generation now uses a centralized method instead of per module code
+
+### Bugfixes
+* diff now returns as snakecase instead of camelcase
+
+
 ## v0.0.1
 
-### Documenttion
+### Documentation
 * Improve type documentation for module parameters
 * Improve HTTP error reporting for 400 errors
 

--- a/plugins/module_utils/network/meraki/meraki.py
+++ b/plugins/module_utils/network/meraki/meraki.py
@@ -246,9 +246,15 @@ class MerakiModule(object):
     def generate_diff(self, before, after):
         """Creates a diff based on two objects. Applies to the object and returns nothing.
         """
-        diff = recursive_diff(before, after)
-        self.result['diff'] = {'before': diff[0],
-                               'after': diff[1]}
+        try:
+            diff = recursive_diff(before, after)
+            self.result['diff'] = {'before': diff[0],
+                                   'after': diff[1]}
+        except AttributeError:  # Normally for passing a list instead of a dict
+            diff = recursive_diff({'data': before},
+                                  {'data': after})
+            self.result['diff'] = {'before': diff[0]['data'],
+                                   'after': diff[1]['data']}
 
     def get_orgs(self):
         """Downloads all organizations for a user."""
@@ -442,6 +448,7 @@ class MerakiModule(object):
             if 'data' in self.result:
                 try:
                     self.result['data'] = self.convert_camel_to_snake(self.result['data'])
+                    self.result['diff'] = self.convert_camel_to_snake(self.result['diff'])
                 except (KeyError, AttributeError):
                     pass
         self.module.exit_json(**self.result)

--- a/plugins/module_utils/network/meraki/meraki.py
+++ b/plugins/module_utils/network/meraki/meraki.py
@@ -10,7 +10,7 @@ import time
 import os
 import re
 from ansible.module_utils.basic import AnsibleModule, json, env_fallback
-from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict, recursive_diff
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils._text import to_native, to_bytes, to_text
@@ -242,6 +242,13 @@ class MerakiModule(object):
                 # self.fail_json(msg="Fallback", original=original, proposed=proposed)
                 return True
         return False
+
+    def generate_diff(self, before, after):
+        """Creates a diff based on two objects. Applies to the object and returns nothing.
+        """
+        diff = recursive_diff(before, after)
+        self.result['diff'] = {'before': diff[0],
+                               'after': diff[1]}
 
     def get_orgs(self):
         """Downloads all organizations for a user."""

--- a/plugins/modules/meraki_admin.py
+++ b/plugins/modules/meraki_admin.py
@@ -354,11 +354,8 @@ def create_admin(meraki, org_id, name, email):
             payload['networks'] = []
         if meraki.is_update_required(is_admin_existing, payload) is True:
             if meraki.module.check_mode is True:
-                diff = recursive_diff(is_admin_existing, payload)
+                meraki.generate_diff(is_admin_existing, payload)
                 is_admin_existing.update(payload)
-                meraki.result['diff'] = {'before': diff[0],
-                                         'after': diff[1],
-                                         }
                 meraki.result['changed'] = True
                 meraki.result['data'] = payload
                 meraki.exit_json(**meraki.result)

--- a/plugins/modules/meraki_content_filtering.py
+++ b/plugins/modules/meraki_content_filtering.py
@@ -216,11 +216,8 @@ def main():
         proposed = current.copy()
         proposed.update(payload)
         if meraki.is_update_required(current, payload) is True:
-            meraki.result['diff'] = dict()
-            diff = recursive_diff(current, payload)
-            meraki.result['diff']['before'] = diff[0]
-            meraki.result['diff']['after'] = diff[1]
             if module.check_mode:
+                meraki.generate_diff(current, payload)
                 current.update(payload)
                 meraki.result['changed'] = True
                 meraki.result['data'] = current
@@ -228,6 +225,7 @@ def main():
             response = meraki.request(path, method='PUT', payload=json.dumps(payload))
             meraki.result['data'] = response
             meraki.result['changed'] = True
+            meraki.generate_diff(current, response)
         else:
             meraki.result['data'] = current
             if module.check_mode:

--- a/plugins/modules/meraki_firewalled_services.py
+++ b/plugins/modules/meraki_firewalled_services.py
@@ -211,19 +211,15 @@ def main():
             if meraki.check_mode is True:
                 diff_payload = {'service': meraki.params['service']}  # Need to add service as it's not in payload
                 diff_payload.update(payload)
-                diff = recursive_diff(original, diff_payload)
+                meraki.generate_diff(original, diff_payload)
                 original.update(payload)
-                meraki.result['diff'] = {'before': diff[0],
-                                         'after': diff[1]}
                 meraki.result['data'] = original
                 meraki.result['changed'] = True
                 meraki.exit_json(**meraki.result)
             path = meraki.construct_path('service', net_id=net_id, custom={'service': meraki.params['service']})
             response = meraki.request(path, method='PUT', payload=json.dumps(payload))
             if meraki.status == 200:
-                diff = recursive_diff(original, response)
-                meraki.result['diff'] = {'before': diff[0],
-                                         'after': diff[1]}
+                meraki.generate_diff(original, response)
                 meraki.result['data'] = response
                 meraki.result['changed'] = True
         else:

--- a/plugins/modules/meraki_malware.py
+++ b/plugins/modules/meraki_malware.py
@@ -239,21 +239,15 @@ def main():
         original = meraki.request(path, method='GET')
         if meraki.is_update_required(original, payload):
             if meraki.module.check_mode is True:
-                diff = recursive_diff(original, payload)
+                meraki.generate_diff(original, payload)
                 original.update(payload)
-                meraki.result['diff'] = {'before': diff[0],
-                                         'after': diff[1],
-                                         }
                 meraki.result['data'] = original
                 meraki.result['changed'] = True
                 meraki.exit_json(**meraki.result)
             path = meraki.construct_path('update', net_id=net_id)
             data = meraki.request(path, method='PUT', payload=json.dumps(payload))
             if meraki.status == 200:
-                diff = recursive_diff(original, payload)
-                meraki.result['diff'] = {'before': diff[0],
-                                         'after': diff[1],
-                                         }
+                meraki.generate_diff(original, data)
                 meraki.result['data'] = data
                 meraki.result['changed'] = True
         else:

--- a/plugins/modules/meraki_mx_l7_firewall.py
+++ b/plugins/modules/meraki_mx_l7_firewall.py
@@ -452,20 +452,14 @@ def main():
             payload = rename_appid_to_id(payload)
             if meraki.module.check_mode is True:
                 response = restructure_response(payload)
-                diff = recursive_diff(restructure_response(rules), response)
-                meraki.result['diff'] = {'before': diff[0],
-                                         'after': diff[1],
-                                         }
+                meraki.generate_diff(restructure_response(rules), response)
                 meraki.result['data'] = response
                 meraki.result['changed'] = True
                 meraki.exit_json(**meraki.result)
             response = meraki.request(path, method='PUT', payload=json.dumps(payload))
             response = restructure_response(response)
             if meraki.status == 200:
-                diff = recursive_diff(restructure_response(rules), response)
-                meraki.result['diff'] = {'before': diff[0],
-                                         'after': diff[1],
-                                         }
+                meraki.generate_diff(restructure_response(rules), response)
                 meraki.result['data'] = response
                 meraki.result['changed'] = True
         else:

--- a/plugins/modules/meraki_snmp.py
+++ b/plugins/modules/meraki_snmp.py
@@ -281,20 +281,16 @@ def set_snmp(meraki, org_id):
     ignored_parameters = ['v3AuthPass', 'v3PrivPass', 'hostname', 'port', 'v2CommunityString', 'v3User']
     if meraki.is_update_required(snmp, full_compare, optional_ignore=ignored_parameters):
         if meraki.module.check_mode is True:
-            diff = recursive_diff(snmp, full_compare)
+            meraki.generate_diff(snmp, full_compare)
             snmp.update(payload)
             meraki.result['data'] = snmp
             meraki.result['changed'] = True
-            meraki.result['diff'] = {'before': diff[0],
-                                     'after': diff[1]}
             meraki.exit_json(**meraki.result)
         r = meraki.request(path,
                            method='PUT',
                            payload=json.dumps(payload))
         if meraki.status == 200:
-            diff = recursive_diff(snmp, r)
-            meraki.result['diff'] = {'before': diff[0],
-                                     'after': diff[1]}
+            meraki.generate_diff(snmp, r)
             meraki.result['changed'] = True
             return r
     else:

--- a/plugins/modules/meraki_syslog.py
+++ b/plugins/modules/meraki_syslog.py
@@ -230,16 +230,15 @@ def main():
 
         if meraki.is_update_required(original, payload):
             if meraki.module.check_mode is True:
-                diff = recursive_diff(original, payload)
+                meraki.generate_diff(original, payload)
                 original.update(payload)
-                meraki.result['diff'] = {'before': diff[0],
-                                         'after': diff[1]}
                 meraki.result['data'] = original
                 meraki.result['changed'] = True
                 meraki.exit_json(**meraki.result)
             path = meraki.construct_path('query_update', net_id=net_id)
             r = meraki.request(path, method='PUT', payload=json.dumps(payload))
             if meraki.status == 200:
+                meraki.generate_diff(original, r)
                 meraki.result['data'] = r
                 meraki.result['changed'] = True
         else:

--- a/plugins/modules/meraki_vlan.py
+++ b/plugins/modules/meraki_vlan.py
@@ -431,6 +431,7 @@ def main():
                 response = meraki.request(path, method='PUT', payload=json.dumps(payload))
                 meraki.result['changed'] = True
                 meraki.result['data'] = response
+                meraki.generate_diff(original, response)
             else:
                 if meraki.module.check_mode is True:
                     meraki.result['data'] = original

--- a/plugins/modules/meraki_vlan.py
+++ b/plugins/modules/meraki_vlan.py
@@ -421,10 +421,7 @@ def main():
                 payload['vpnNatSubnet'] = meraki.params['vpn_nat_subnet']
             ignored = ['networkId']
             if meraki.is_update_required(original, payload, optional_ignore=ignored):
-                meraki.result['diff'] = dict()
-                diff = recursive_diff(original, payload)
-                meraki.result['diff']['before'] = diff[0]
-                meraki.result['diff']['after'] = diff[1]
+                meraki.generate_diff(original, payload)
                 if meraki.module.check_mode is True:
                     original.update(payload)
                     meraki.result['changed'] = True

--- a/plugins/modules/meraki_webhook.py
+++ b/plugins/modules/meraki_webhook.py
@@ -291,16 +291,15 @@ def main():
             original = meraki.request(path, method='GET')
             if meraki.is_update_required(original, payload):
                 if meraki.check_mode is True:
-                    diff = recursive_diff(original, payload)
+                    meraki.generate_diff(original, payload)
                     original.update(payload)
-                    meraki.result['diff'] = {'before': diff[0],
-                                             'after': diff[1]}
                     meraki.result['data'] = original
                     meraki.result['changed'] = True
                     meraki.exit_json(**meraki.result)
                 path = meraki.construct_path('update', net_id=net_id, custom={'hookid': webhook_id})
                 response = meraki.request(path, method='PUT', payload=json.dumps(payload))
                 if meraki.status == 200:
+                    meraki.generate_diff(original, response)
                     meraki.result['data'] = response
                     meraki.result['changed'] = True
             else:


### PR DESCRIPTION
Much of the diff code is repeated through each module. This pull request creates a `generate_diff(before, after)` method which will compare the data structures and assign the results to the module, so no assignment is necessary.

meraki_nat cannot take this method since it uses a more complex data structure to return data.

Fixes to #36 