### PR TITLE
meraki_organization - Add confirmation for organization deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.0.0
+
+### Enhancements
+* meraki_organzation - A confirmation is needed to delete an organization since it can be a catastrophic change
+
 ## v0.1.0
 
 ### Enhancements

--- a/plugins/modules/meraki_organization.py
+++ b/plugins/modules/meraki_organization.py
@@ -135,6 +135,7 @@ def main():
                          state=dict(type='str', choices=['absent', 'present', 'query'], default='present'),
                          org_name=dict(type='str', aliases=['name', 'organization']),
                          org_id=dict(type='str', aliases=['id']),
+                         delete_confirm=dict(type='str'),
                          )
 
     # the AnsibleModule object will be our abstraction working with Ansible
@@ -217,6 +218,8 @@ def main():
             org_id = meraki.get_org_id(meraki.params['org_name'])
         elif meraki.params['org_id'] is not None:
             org_id = meraki.params['org_id']
+        if meraki.params['delete_confirm'] != org_id:
+            meraki.fail_json(msg="delete_confirm must match the network ID of the network to be deleted.")
         if meraki.check_mode is True:
             meraki.result['data'] = {}
             meraki.result['changed'] = True

--- a/tests/integration/targets/meraki_organization/tasks/tests.yml
+++ b/tests/integration/targets/meraki_organization/tasks/tests.yml
@@ -31,6 +31,9 @@
   - debug:
       msg: '{{cloned_org}}'
 
+  - set_fact:
+      cloned_net_id: '{{cloned_org.data.id}}'
+
   - name: Rename IntTestOrg
     meraki_organization:
       auth_key: '{{ auth_key }}'
@@ -95,12 +98,29 @@
         - 'query_org.data.name == "IntTestOrgRenamed"'
         - 'query_org_id.data.id == query_org.data.id'
 
+  - name: Delete without confirmation code
+    meraki_organization:
+      auth_key: '{{ auth_key }}'
+      state: absent
+      org_name: IntTestOrgCloned
+    register: delete_no_confirm
+    ignore_errors: yes
+
+  - assert:
+      that:
+        'delete_no_confirm.msg == "delete_confirm must match the network ID of the network to be deleted."'
+
   always:
+  # - name: Pause playbook for more reliable deletion
+  #   pause:
+  #     minutes: 1
+
   - name: Delete cloned organizations with check mode
     meraki_organization:
       auth_key: '{{ auth_key }}'
       state: absent
       org_name: IntTestOrgCloned
+      delete_confirm: '{{cloned_net_id}}'
     register: deleted_org_check
     check_mode: yes
 
@@ -113,6 +133,7 @@
       auth_key: '{{ auth_key }}'
       state: absent
       org_name: IntTestOrgCloned
+      delete_confirm: '{{cloned_net_id}}'
     register: deleted_org
 
   - name: Delete renamed organization by id
@@ -120,6 +141,7 @@
       auth_key: '{{ auth_key }}'
       state: absent
       org_id: '{{renamed_org_id}}'
+      delete_confirm: '{{renamed_org_id}}'
     register: deleted_org_id
 
   - assert:


### PR DESCRIPTION
Deleting an organization is catastrophic. This pull request adds a required confirmation for deletion of an organization. This isn't needed and has some pushback within Ansible, but I'm adding it to be safe.