### PR TITLE
meraki_mx_l3_firewall - Fix firewall rules not updating

### DIFF
--- a/plugins/modules/meraki_mx_l3_firewall.py
+++ b/plugins/modules/meraki_mx_l3_firewall.py
@@ -56,18 +56,22 @@ options:
             dest_port:
                 description:
                 - Comma separated list of destination port numbers to match against.
+                - C(Any) must be capitalized.
                 type: str
             dest_cidr:
                 description:
                 - Comma separated list of CIDR notation destination networks.
+                - C(Any) must be capitalized.
                 type: str
             src_port:
                 description:
                 - Comma separated list of source port numbers to match against.
+                - C(Any) must be capitalized.
                 type: str
             src_cidr:
                 description:
                 - Comma separated list of CIDR notation source networks.
+                - C(Any) must be capitalized.
                 type: str
             comment:
                 description:

--- a/plugins/modules/meraki_mx_l3_firewall.py
+++ b/plugins/modules/meraki_mx_l3_firewall.py
@@ -299,9 +299,14 @@ def main():
             if update is False:
                 default_rule = rules[len(rules) - 1].copy()
                 del rules[len(rules) - 1]  # Remove default rule for comparison
-                for r in range(len(rules) - 1):
-                    if meraki.is_update_required(rules[r], payload['rules'][r]) is True:
+                if len(rules) - 1 == 0:
+                    if meraki.is_update_required(rules[0], payload['rules'][0]) is True:
+                        # meraki.fail_json(msg="Compare", original=rules[0], payload=payload['rules'][0])
                         update = True
+                else:
+                    for r in range(len(rules) - 1):
+                        if meraki.is_update_required(rules[r], payload['rules'][r]) is True:
+                            update = True
                 rules.append(default_rule)
         except KeyError:
             pass

--- a/tests/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
+++ b/tests/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
@@ -39,8 +39,8 @@
       state: present
       rules:
         - comment: Deny to documentation address
-          src_port: any
-          src_cidr: any
+          src_port: Any
+          src_cidr: Any
           dest_port: 80,443
           dest_cidr: 192.0.1.1/32
           protocol: tcp
@@ -69,8 +69,8 @@
       state: present
       rules:
         - comment: Deny to documentation address
-          src_port: any
-          src_cidr: any
+          src_port: Any
+          src_cidr: Any
           dest_port: 80,443
           dest_cidr: 192.0.1.1/32
           protocol: tcp
@@ -98,8 +98,8 @@
       state: present
       rules:
         - comment: Deny to documentation address
-          src_port: any
-          src_cidr: any
+          src_port: Any
+          src_cidr: Any
           dest_port: 80,443
           dest_cidr: 192.0.1.1/32
           protocol: tcp
@@ -114,6 +114,31 @@
       that:
         - create_one_idempotent.changed == False
         - create_one_idempotent.data is defined
+
+  - name: Update one existing rule
+    meraki_mx_l3_firewall:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{test_org_name}}'
+      net_name: TestNetAppliance
+      state: present
+      rules:
+        - comment: Deny all documentation addresses
+          src_port: Any
+          src_cidr: Any
+          dest_port: 80,443
+          dest_cidr: 192.0.1.1/32,192.0.1.2/32
+          protocol: tcp
+          policy: deny
+    delegate_to: localhost
+    register: update_one
+
+  - debug:
+      msg: '{{update_one}}'
+
+  - assert:
+      that:
+        - update_one.changed == True
+        - update_one.data is defined
 
   - name: Create syslog in network
     meraki_syslog:
@@ -137,8 +162,8 @@
       state: present
       rules:
         - comment: Deny to documentation address
-          src_port: any
-          src_cidr: any
+          src_port: Any
+          src_cidr: Any
           dest_port: 80,443
           dest_cidr: 192.0.1.1/32
           protocol: tcp
@@ -165,8 +190,8 @@
       state: present
       rules:
         - comment: Deny to documentation address
-          src_port: any
-          src_cidr: any
+          src_port: Any
+          src_cidr: Any
           dest_port: 80,443
           dest_cidr: 192.0.1.1/32
           protocol: tcp
@@ -207,8 +232,8 @@
       state: present
       rules:
         - comment: Deny to documentation address
-          src_port: any
-          src_cidr: any
+          src_port: Any
+          src_cidr: Any
           dest_port: 80,443
           dest_cidr: 192.0.1.1/32
           protocol: tcp


### PR DESCRIPTION
Firewall rules were not updating due to `range()` not working if there was only one non-default firewall rule. This pull request fixes this. I also discovered a bug with integration tests where `any` wasn't matching with the response from Meraki. I consulted Meraki and they clarified what I should expect. I've updated integration tests and documentation to reflect.

Fixes #61 

CC @pokepoke81