### PR TITLE
Add build_ignore to Galaxy metadata

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,3 +18,6 @@ tags:
 - switching
 - cisco
 version: 1.0.1
+build_ignore:
+- tests/output/*
+- '*tar.gz'


### PR DESCRIPTION
These entries are in your `.gitignore`, so that strongly suggests that it's safe to not put in the build. From a test build, the contents match expectations:

```
$ tree ~/.ansible/collections/ansible_collections/cisco/meraki/
/Users/alancoding/.ansible/collections/ansible_collections/cisco/meraki/
├── CHANGELOG.md
├── FILES.json
├── MANIFEST.json
├── README.md
├── plugins
│   ├── module_utils
│   │   └── network
│   │       └── meraki
│   │           ├── __init__.py
│   │           └── meraki.py
│   └── modules
│       ├── __init__.py
│       ├── meraki_admin.py
│       ├── meraki_config_template.py
│       ├── meraki_content_filtering.py
│       ├── meraki_device.py
│       ├── meraki_firewalled_services.py
│       ├── meraki_intrusion_prevention.py
│       ├── meraki_malware.py
│       ├── meraki_mr_l3_firewall.py
│       ├── meraki_mx_l3_firewall.py
│       ├── meraki_mx_l7_firewall.py
│       ├── meraki_nat.py
│       ├── meraki_network.py
│       ├── meraki_organization.py
│       ├── meraki_snmp.py
│       ├── meraki_ssid.py
│       ├── meraki_static_route.py
│       ├── meraki_switch_access_list.py
│       ├── meraki_switch_storm_control.py
│       ├── meraki_switchport.py
│       ├── meraki_syslog.py
│       ├── meraki_vlan.py
│       └── meraki_webhook.py
└── tests
    └── integration
        ├── inventory.networking.template
        ├── target-prefixes.network
        └── targets
            ├── meraki_admin
            │   ├── aliases
            │   └── tasks
            │       └── main.yml
            ├── meraki_config_template
            │   ├── aliases
            │   └── tasks
            │       └── main.yml
            ├── meraki_content_filtering
            │   ├── aliases
            │   └── tasks
            │       └── main.yml
            ├── meraki_device
            │   ├── aliases
            │   └── tasks
            │       └── main.yml
            ├── meraki_firewalled_services
            │   ├── aliases
            │   └── tasks
            │       ├── main.yml
            │       └── tests.yml
            ├── meraki_intrusion_prevention
            │   ├── aliases
            │   └── tasks
            │       ├── main.yml
            │       └── tests.yml
            ├── meraki_malware
            │   ├── aliases
            │   └── tasks
            │       └── main.yml
            ├── meraki_mr_l3_firewall
            │   ├── aliases
            │   └── tasks
            │       └── main.yml
            ├── meraki_mx_l3_firewall
            │   ├── aliases
            │   └── tasks
            │       └── main.yml
            ├── meraki_mx_l7_firewall
            │   ├── aliases
            │   └── tasks
            │       ├── main.yml
            │       └── tests.yml
            ├── meraki_nat
            │   ├── aliases
            │   └── tasks
            │       ├── main.yml
            │       └── tests.yml
            ├── meraki_network
            │   ├── aliases
            │   └── tasks
            │       └── main.yml
            ├── meraki_organization
            │   ├── aliases
            │   └── tasks
            │       ├── main.yml
            │       └── tests.yml
            ├── meraki_snmp
            │   ├── aliases
            │   └── tasks
            │       └── main.yml
            ├── meraki_ssid
            │   ├── aliases
            │   └── tasks
            │       └── main.yml
            ├── meraki_static_route
            │   ├── aliases
            │   └── tasks
            │       └── main.yml
            ├── meraki_switch_access_list
            │   ├── aliases
            │   └── tasks
            │       ├── main.yml
            │       └── tests.yml
            ├── meraki_switch_storm_control
            │   ├── aliases
            │   └── tasks
            │       └── main.yml
            ├── meraki_switchport
            │   ├── aliases
            │   └── tasks
            │       └── main.yml
            ├── meraki_syslog
            │   ├── aliases
            │   └── tasks
            │       └── main.yml
            ├── meraki_vlan
            │   ├── aliases
            │   └── tasks
            │       └── main.yml
            └── meraki_webhook
                ├── aliases
                └── tasks
                    ├── main.yml
                    └── tests.yml

52 directories, 82 files
```

That's the same file count as the repo itself