### PR TITLE
meraki_mx_l3_firewall - Remove unnecessary org lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugfixes
 * meraki_static_route - Fix idempotency bugs triggered with certain parameters
+* meraki_mx_l3_firewall - Remove unnecessary org lookup which may crash
 
 ## v1.0.1
 

--- a/plugins/modules/meraki_mx_l3_firewall.py
+++ b/plugins/modules/meraki_mx_l3_firewall.py
@@ -268,7 +268,6 @@ def main():
     # manipulate or modify the state as needed (this is going to be the
     # part where your module will do what it needs to do)
     org_id = meraki.params['org_id']
-    orgs = None
     if org_id is None:
         orgs = meraki.get_orgs()
         for org in orgs:
@@ -276,8 +275,6 @@ def main():
                 org_id = org['id']
     net_id = meraki.params['net_id']
     if net_id is None:
-        if orgs is None:
-            orgs = meraki.get_orgs()
         net_id = meraki.get_net_id(net_name=meraki.params['net_name'],
                                    data=meraki.get_nets(org_id=org_id))
 

--- a/tests/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
+++ b/tests/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
@@ -64,7 +64,7 @@
   - name: Set one firewall rule
     meraki_mx_l3_firewall:
       auth_key: '{{ auth_key }}'
-      org_name: '{{test_org_name}}'
+      org_id: '{{test_org_id}}'
       net_name: TestNetAppliance
       state: present
       rules:


### PR DESCRIPTION
This removes an unnecessary org lookup that is triggered when `org_id` and `net_name` are used in tandem. It was causing a crash and wasn't needed anyways.

Fixes #73 