### PR TITLE
meraki_mx_l3_firewall - Fix idempotency with any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
 ## v1.1.0
+<<<<<<< HEAD
 
 ### Features
 * meraki_vlan - Add full DHCP server configuration support
+=======
+>>>>>>> Change version number in CHANGELOG
 
 ## Bugfixes
 * meraki_mx_l3_firewall - Fix idempotency when 'any' is passed as a parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Features
 * meraki_vlan - Add full DHCP server configuration support
 
+## Bugfixes
+* meraki_mx_l3_firewall - Fix idempotency when 'any' is passed as a parameter
+
 ## v1.0.3
 
 ### Miscellaneous

--- a/plugins/modules/meraki_mx_l3_firewall.py
+++ b/plugins/modules/meraki_mx_l3_firewall.py
@@ -221,6 +221,21 @@ def get_rules(meraki, net_id):
     if meraki.status == 200:
         return response
 
+def normalize_case(rule):
+    any = ['any', 'Any', 'ANY']
+    if 'srcPort' in rule:
+        if rule['srcPort'] in any:
+            rule['srcPort'] = 'Any'
+    if 'srcCidr' in rule:
+        if rule['srcCidr'] in any:
+            rule['srcCidr'] = 'Any'
+    if 'destPort' in rule:
+        if rule['destPort'] in any:
+            rule['destPort'] = 'Any'
+    if 'destCidr' in rule:
+        if rule['destCidr'] in any:
+            rule['destCidr'] = 'Any'
+
 
 def main():
     # define the available arguments/parameters that a user can pass to
@@ -301,11 +316,16 @@ def main():
                 default_rule = rules[len(rules) - 1].copy()
                 del rules[len(rules) - 1]  # Remove default rule for comparison
                 if len(rules) - 1 == 0:
+                    normalize_case(rules[0])
+                    normalize_case(payload['rules'][0])
+                    # meraki.fail_json(msg='Compare', original=rules, payload=payload)
                     if meraki.is_update_required(rules[0], payload['rules'][0]) is True:
-                        # meraki.fail_json(msg="Compare", original=rules[0], payload=payload['rules'][0])
                         update = True
                 else:
                     for r in range(len(rules) - 1):
+                        normalize_case(rules[r])
+                        normalize_case(payload['rules'][r])
+                        # meraki.fail_json(msg='Full Compare', original=rules, payload=payload)
                         if meraki.is_update_required(rules[r], payload['rules'][r]) is True:
                             update = True
                 rules.append(default_rule)

--- a/tests/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
+++ b/tests/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
@@ -207,6 +207,43 @@
       that:
         - default_syslog.data is defined
 
+  - name: Set protocol to any for idempotency check
+    meraki_mx_l3_firewall:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{test_org_name}}'
+      net_name: TestNetAppliance
+      state: present
+      rules:
+        - comment: Deny to documentation address
+          src_port: any
+          src_cidr: any
+          dest_port: any
+          dest_cidr: 192.0.1.1/32
+          protocol: any
+          policy: deny        
+    delegate_to: localhost
+
+  - name: Check for protocol any idempotency
+    meraki_mx_l3_firewall:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{test_org_name}}'
+      net_name: TestNetAppliance
+      state: present
+      rules:
+        - comment: Deny to documentation address
+          src_port: any
+          src_cidr: any
+          dest_port: any
+          dest_cidr: 192.0.1.1/32
+          protocol: any
+          policy: deny        
+    delegate_to: localhost
+    register: any_idempotency
+
+  - assert:
+      that:
+        - any_idempotency is not changed
+
   - name: Query firewall rules
     meraki_mx_l3_firewall:
       auth_key: '{{ auth_key }}'


### PR DESCRIPTION
This PR fixes idempotency problems due to capitalization of parameters called 'any'. If this works I'll update related modules with the same fix.

Fixes #80 