### PR TITLE
WIP: meraki_ssid - Add support for WPA3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.1.0
+
+### Enhancements
+* meraki_ssid - Add support for WPA3
+
 ## v1.0.3
 
 ## Miscellaneous

--- a/plugins/modules/meraki_ssid.py
+++ b/plugins/modules/meraki_ssid.py
@@ -69,7 +69,7 @@ options:
         description:
         - Encryption mode within WPA2 specification.
         type: str
-        choices: [WPA1 and WPA2, WPA2 only]
+        choices: [WPA1 only, WPA1 and WPA2, WPA2 only, WPA3 Transition Mode, WPA3 only]
     splash_page:
         description:
         - Set to enable splash page and specify type of splash.
@@ -460,7 +460,12 @@ def main():
                          auth_mode=dict(type='str', choices=['open', 'psk', 'open-with-radius', '8021x-meraki', '8021x-radius']),
                          encryption_mode=dict(type='str', choices=['wpa', 'eap', 'wpa-eap']),
                          psk=dict(type='str', no_log=True),
-                         wpa_encryption_mode=dict(type='str', choices=['WPA1 and WPA2', 'WPA2 only']),
+                         wpa_encryption_mode=dict(type='str', choices=['WPA1 only',
+                                                                       'WPA1 and WPA2', 
+                                                                       'WPA2 only',
+                                                                       'WPA3 Transition Mode',
+                                                                       'WPA3 only',
+                                                                       ]),
                          splash_page=dict(type='str', choices=['None',
                                                                'Click-through splash page',
                                                                'Billing',

--- a/tests/integration/targets/meraki_ssid/tasks/main.yml
+++ b/tests/integration/targets/meraki_ssid/tasks/main.yml
@@ -349,6 +349,23 @@
       that:
         - set_radius_server_idempotent is not changed
 
+  - name: Set WPA3
+    meraki_ssid:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: TestNetSSID
+      name: AnsibleSSID
+      encryption_mode: wpa
+      wpa_encryption_mode: WPA3 only
+      auth_mode: 8021x-radius
+    delegate_to: localhost
+    register: wpa3
+
+  - assert:
+      that:
+        - wpa3.data.wpa_encryption_mode == 'WPA3 only'
+
   #################
   # Error testing #
   #################


### PR DESCRIPTION
Meraki is adding support for WPA3. This adds the support but it is in beta and requires a call into Meraki to enable it. This is on hold for now.