### PR TITLE
meraki_admin - Properly handle network.network and network.id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bugfixes
 * meraki_device - Rewrite module to be more reliable when hostname is specified
+* meraki_admin - Fix crash when specifying networks parameter
 
 ## v1.2.1
 

--- a/plugins/modules/meraki_admin.py
+++ b/plugins/modules/meraki_admin.py
@@ -63,6 +63,10 @@ options:
                 description:
                 - Network ID for which administrator should have privileges assigned.
                 type: str
+            network:
+                description:
+                - Network name for which administrator should have privileges assigned.
+                type: str
             access:
                 description:
                 - The privilege of the dashboard administrator on the network.
@@ -310,11 +314,17 @@ def delete_admin(meraki, org_id, admin_id):
 def network_factory(meraki, networks, nets):
     networks_new = []
     for n in networks:
-        networks_new.append({'id': meraki.get_net_id(org_name=meraki.params['org_name'],
-                                                     net_name=n['network'],
-                                                     data=nets),
-                             'access': n['access']
-                             })
+        if 'network' in n:
+            networks_new.append({'id': meraki.get_net_id(org_name=meraki.params['org_name'],
+                                                         net_name=n['network'],
+                                                         data=nets),
+                                 'access': n['access']
+                                 })
+        elif 'id' in n:
+            networks_new.append({'id': n['id'],
+                                 'access': n['access']
+                                 })
+
     return networks_new
 
 
@@ -379,6 +389,7 @@ def main():
     # the module
 
     network_arg_spec = dict(id=dict(type='str'),
+                            network=dict(type='str'),
                             access=dict(type='str'),
                             )
 

--- a/tests/integration/targets/meraki_admin/tasks/main.yml
+++ b/tests/integration/targets/meraki_admin/tasks/main.yml
@@ -96,9 +96,6 @@
     register: create_tags_check
     check_mode: yes
 
-  - debug:
-      var: create_tags_check
-
   - assert:
       that:
         - create_tags_check is changed
@@ -178,9 +175,14 @@
       org_name: '{{test_org_name}}'
       net_name: '{{item}}'
       type: switch
+    register: new_networks
     loop:
       - TestNet
       - TestNet2
+
+  - set_fact:
+      testnet_id: new_networks.results[0].data.id
+      testnet2_id: new_networks.results[1].data.id
 
   - name: Create administrator with networks with check mode
     meraki_admin:
@@ -193,7 +195,7 @@
       networks:
         - network: TestNet
           access: read-only
-        - network: TestNet2
+        - id: testnet2_id
           access: full
     delegate_to: localhost
     register: create_network_check


### PR DESCRIPTION
Fixes #97 

- Module was accepting networks.network key when it shouldn't have
- Module now supports both networks.network and network.id