### PR TITLE
meraki_content_filtering - Update URLs for content filtering endpoints in API v1

### DIFF
--- a/changelogs/fragments/meraki_content_filtering.yml
+++ b/changelogs/fragments/meraki_content_filtering.yml
@@ -1,0 +1,2 @@
+trivial:
+  - meraki_content_filtering - Update URLs to content filtering endpoints

--- a/plugins/modules/meraki_content_filtering.py
+++ b/plugins/modules/meraki_content_filtering.py
@@ -192,8 +192,8 @@ def main():
     meraki = MerakiModule(module, function='content_filtering')
     module.params['follow_redirects'] = 'all'
 
-    category_urls = {'content_filtering': '/networks/{net_id}/contentFiltering/categories'}
-    policy_urls = {'content_filtering': '/networks/{net_id}/contentFiltering'}
+    category_urls = {'content_filtering': '/networks/{net_id}/appliance/contentFiltering/categories'}
+    policy_urls = {'content_filtering': '/networks/{net_id}/appliance/contentFiltering'}
 
     meraki.url_catalog['categories'] = category_urls
     meraki.url_catalog['policy'] = policy_urls


### PR DESCRIPTION
API v1 is requiring a different endpoint URL