### PR TITLE
meraki_ssid - Fix formatting on VLAN tags

### DIFF
--- a/changelogs/fragments/ssid_tags.yml
+++ b/changelogs/fragments/ssid_tags.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - meraki_ssid - Specifying tags for VLAN information would crash as it was an improper type

--- a/plugins/modules/meraki_ssid.py
+++ b/plugins/modules/meraki_ssid.py
@@ -407,6 +407,8 @@ def construct_payload(meraki):
 
     if meraki.params['ap_tags_vlan_ids'] is not None:
         for i in payload['apTagsAndVlanIds']:
+            if 'tags' in i:
+                i['tags'] = ','.join(i['tags'])
             try:
                 i['vlanId'] = i['vlan_id']
                 del i['vlan_id']


### PR DESCRIPTION
The following error was generated during integration test executions:

```
TASK [meraki_ssid : Set VLAN arg spec] *****************************************
fatal: [localhost]: FAILED! => {"body": {"errors": ["'tags' must be a string"]}, "changed": false, "msg": "HTTP error 400 - https://api.meraki.com/api/v0/networks/numberhere/ssids/1 - [\"'tags' must be a string\"]", "response": "HTTP Error 400: Bad Request", "status": 400}
```

This PR fixes the crash by converting a list to a comma separated string.