### PR TITLE
Reduce next release by 122 MB

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -27,3 +27,4 @@ build_ignore:
 - '.gitignore'
 - '.env'
 - '.github'
+- 'tests/output/'


### PR DESCRIPTION
The current release (2.1.1) has 122 MB of tests/output/ which are totally unnecessary.