### PR TITLE
Add nested dictionary for voice_vlan arg_spec to allow a state of absent to remove voice vlan.

### DIFF
--- a/changelogs/fragments/0238-vvlan-allow-null.yml
+++ b/changelogs/fragments/0238-vvlan-allow-null.yml
@@ -1,5 +1,2 @@
-breaking_changes:
-  - voice_vlan now requires a nested dictionary with vlan and state keys.
-
 bugfixes:
   - Allow a state of absent in voice vlan to allow the value to be nulled out(https://github.com/CiscoDevNet/ansible-meraki/issues/238)

--- a/plugins/modules/meraki_ms_switchport.py
+++ b/plugins/modules/meraki_ms_switchport.py
@@ -523,7 +523,6 @@ def main():
         original = meraki.request(query_path, method='GET')
         # Check voiceVlan to see if state is absent to remove the vlan.
         if meraki.params.get('voice_vlan'):
-            meraki.fail_json(msg='got to if', payload=type(meraki.params.get('voice_vlan')))
             if meraki.params.get('voice_vlan')['state'] == 'absent': 
                 payload['voiceVlan'] = None
         if meraki.params.get('mac_allow_list'):

--- a/plugins/modules/meraki_ms_switchport.py
+++ b/plugins/modules/meraki_ms_switchport.py
@@ -497,7 +497,7 @@ def main():
             meraki.result['data'] = response
     elif meraki.params['state'] == 'present':
         payload = assemble_payload(meraki)
-        meraki.fail_json(msg='payload', payload=payload)
+        # meraki.fail_json(msg='payload', payload=payload)
         allowed = set()  # Use a set to remove duplicate items
         if meraki.params['allowed_vlans'][0] == 'all':
             allowed.add('all')
@@ -522,6 +522,7 @@ def main():
         # Check voiceVlan to see if state is absent to remove the vlan.
         if meraki.params.get('voice_vlan'):
             if meraki.params.get('voice_vlan')['state'] == 'absent':
+                meraki.fail_json(msg='got to if', payload=payload)
                 payload['voiceVlan'] = None
         if meraki.params.get('mac_allow_list'):
             macs = get_mac_list(original.get('macAllowList'), meraki.params["mac_allow_list"].get("macs"), meraki.params["mac_allow_list"].get("state"))

--- a/plugins/modules/meraki_ms_switchport.py
+++ b/plugins/modules/meraki_ms_switchport.py
@@ -439,7 +439,10 @@ def main():
                          enabled=dict(type='bool', default=True),
                          type=dict(type='str', choices=['access', 'trunk'], default='access'),
                          vlan=dict(type='int'),
-                         voice_vlan=dict(type='int'),
+                         voice_vlan=dict(
+                             vlan=dict(type='int'),
+                             state=dict(type='str', choices=['present', 'absent'], default='present')
+                         ),
                          allowed_vlans=dict(type='list', elements='str', default='all'),
                          poe_enabled=dict(type='bool', default=True),
                          isolation_enabled=dict(type='bool', default=False),
@@ -516,6 +519,10 @@ def main():
                                                               'number': meraki.params['number'],
                                                               })
         original = meraki.request(query_path, method='GET')
+        # Check voiceVlan to see if state is absent to remove the vlan.
+        if meraki.params.get('voice_vlan'):
+            if meraki.params.get('voice_vlan')['state'] == 'absent':
+                payload['voiceVlan'] = None
         if meraki.params.get('mac_allow_list'):
             macs = get_mac_list(original.get('macAllowList'), meraki.params["mac_allow_list"].get("macs"), meraki.params["mac_allow_list"].get("state"))
             payload['macAllowList'] = macs

--- a/plugins/modules/meraki_ms_switchport.py
+++ b/plugins/modules/meraki_ms_switchport.py
@@ -431,6 +431,11 @@ def main():
         state=dict(type='str', choices=['merged', 'replaced', 'deleted'], default='replaced'),
     )
 
+    voice_vlan_arg_spec = dict(
+        vlan=dict(type='int'),
+        state=dict(type='str', choices=['present', 'absent'], default='present'),
+    )
+
     argument_spec.update(state=dict(type='str', choices=['present', 'query'], default='query'),
                          serial=dict(type='str', required=True),
                          number=dict(type='str'),
@@ -439,10 +444,7 @@ def main():
                          enabled=dict(type='bool', default=True),
                          type=dict(type='str', choices=['access', 'trunk'], default='access'),
                          vlan=dict(type='int'),
-                         voice_vlan=dict(
-                             vlan=dict(type='int'),
-                             state=dict(type='str', choices=['present', 'absent'], default='present'),
-                         ),
+                         voice_vlan=dict(type='dict', options=voice_vlan_arg_spec),
                          allowed_vlans=dict(type='list', elements='str', default='all'),
                          poe_enabled=dict(type='bool', default=True),
                          isolation_enabled=dict(type='bool', default=False),

--- a/plugins/modules/meraki_ms_switchport.py
+++ b/plugins/modules/meraki_ms_switchport.py
@@ -108,6 +108,7 @@ options:
         description:
         - VLAN number assigned to a port for voice traffic.
         - Only applicable to access port type.
+        - Only applicable if voice_vlan_state is set to present.
         type: int
     voice_vlan_state:
         description:
@@ -471,7 +472,7 @@ def main():
                            )
     meraki = MerakiModule(module, function='switchport')
     if meraki.params.get('voice_vlan_state') == "absent" and meraki.params.get('voice_vlan'):
-        meraki.fail_json(msg='voice_vlan_state cant be "absent" while voice_vlan is also defined.')
+        meraki.fail_json(msg='voice_vlan_state cant be `absent` while voice_vlan is also defined.')
 
     meraki.params['follow_redirects'] = 'all'
 

--- a/plugins/modules/meraki_ms_switchport.py
+++ b/plugins/modules/meraki_ms_switchport.py
@@ -523,6 +523,7 @@ def main():
         if meraki.params.get('voice_vlan'):
             if meraki.params.get('voice_vlan')['state'] == 'absent':
                 payload['voiceVlan'] = None
+        meraki.fail_json(msg='Compare', original=original, payload=payload)
         if meraki.params.get('mac_allow_list'):
             macs = get_mac_list(original.get('macAllowList'), meraki.params["mac_allow_list"].get("macs"), meraki.params["mac_allow_list"].get("state"))
             payload['macAllowList'] = macs

--- a/plugins/modules/meraki_ms_switchport.py
+++ b/plugins/modules/meraki_ms_switchport.py
@@ -525,6 +525,8 @@ def main():
         if meraki.params.get('voice_vlan'):
             if meraki.params.get('voice_vlan')['state'] == 'absent': 
                 payload['voiceVlan'] = None
+            else:
+                payload['voiceVlan'] = meraki.params.get('voice_vlan')['vlan']
         if meraki.params.get('mac_allow_list'):
             macs = get_mac_list(original.get('macAllowList'), meraki.params["mac_allow_list"].get("macs"), meraki.params["mac_allow_list"].get("state"))
             payload['macAllowList'] = macs

--- a/plugins/modules/meraki_ms_switchport.py
+++ b/plugins/modules/meraki_ms_switchport.py
@@ -471,7 +471,7 @@ def main():
                            )
     meraki = MerakiModule(module, function='switchport')
     if meraki.params.get('voice_vlan_state') == "absent" and meraki.params.get('voice_vlan'):
-        meraki.fail_json(msg='Voice Vlan state cant be absent while voice_vlan is also defined.')
+        meraki.fail_json(msg='voice_vlan_state cant be "absent" while voice_vlan is also defined.')
 
     meraki.params['follow_redirects'] = 'all'
 

--- a/plugins/modules/meraki_ms_switchport.py
+++ b/plugins/modules/meraki_ms_switchport.py
@@ -470,6 +470,9 @@ def main():
                            supports_check_mode=True,
                            )
     meraki = MerakiModule(module, function='switchport')
+    if meraki.params.get('voice_vlan_state') == "absent" and meraki.params.get('voice_vlan'):
+        meraki.fail_json(msg='Voice Vlan state cant be absent while voice_vlan is also defined.')
+
     meraki.params['follow_redirects'] = 'all'
 
     if meraki.params['type'] == 'trunk':

--- a/plugins/modules/meraki_ms_switchport.py
+++ b/plugins/modules/meraki_ms_switchport.py
@@ -481,7 +481,7 @@ def main():
     meraki.url_catalog['update'] = update_url
 
     # execute checks for argument completeness
-
+    meraki.fail_json(msg='Compare', payload=meraki.params)
     # manipulate or modify the state as needed (this is going to be the
     # part where your module will do what it needs to do)
     if meraki.params['state'] == 'query':
@@ -523,7 +523,6 @@ def main():
         if meraki.params.get('voice_vlan'):
             if meraki.params.get('voice_vlan')['state'] == 'absent':
                 payload['voiceVlan'] = None
-        meraki.fail_json(msg='Compare', original=original, payload=payload)
         if meraki.params.get('mac_allow_list'):
             macs = get_mac_list(original.get('macAllowList'), meraki.params["mac_allow_list"].get("macs"), meraki.params["mac_allow_list"].get("state"))
             payload['macAllowList'] = macs

--- a/plugins/modules/meraki_ms_switchport.py
+++ b/plugins/modules/meraki_ms_switchport.py
@@ -117,9 +117,10 @@ options:
                 default: present
                 type: str
             vlan:
-            - VLAN number assigned to a port for voice traffic.
-            - Only applicable if state is 'present'.
-            type: int
+                description:
+                - VLAN number assigned to a port for voice traffic.
+                - Only applicable if state is 'present'.
+                type: int
     mac_allow_list:
         description:
         - MAC addresses list that are allowed on a port.

--- a/plugins/modules/meraki_ms_switchport.py
+++ b/plugins/modules/meraki_ms_switchport.py
@@ -481,7 +481,7 @@ def main():
     meraki.url_catalog['update'] = update_url
 
     # execute checks for argument completeness
-    meraki.fail_json(msg='Compare', payload=meraki.params)
+
     # manipulate or modify the state as needed (this is going to be the
     # part where your module will do what it needs to do)
     if meraki.params['state'] == 'query':
@@ -497,7 +497,7 @@ def main():
             meraki.result['data'] = response
     elif meraki.params['state'] == 'present':
         payload = assemble_payload(meraki)
-        # meraki.fail_json(msg='payload', payload=payload)
+        meraki.fail_json(msg='payload', payload=payload)
         allowed = set()  # Use a set to remove duplicate items
         if meraki.params['allowed_vlans'][0] == 'all':
             allowed.add('all')

--- a/plugins/modules/meraki_ms_switchport.py
+++ b/plugins/modules/meraki_ms_switchport.py
@@ -522,7 +522,7 @@ def main():
         # Check voiceVlan to see if state is absent to remove the vlan.
         if meraki.params.get('voice_vlan'):
             if meraki.params.get('voice_vlan')['state'] == 'absent':
-                meraki.fail_json(msg='got to if', payload=payload)
+                meraki.fail_json(msg='got to if', payload=meraki.params.get('voice_vlan'))
                 payload['voiceVlan'] = None
         if meraki.params.get('mac_allow_list'):
             macs = get_mac_list(original.get('macAllowList'), meraki.params["mac_allow_list"].get("macs"), meraki.params["mac_allow_list"].get("state"))

--- a/plugins/modules/meraki_ms_switchport.py
+++ b/plugins/modules/meraki_ms_switchport.py
@@ -441,7 +441,7 @@ def main():
                          vlan=dict(type='int'),
                          voice_vlan=dict(
                              vlan=dict(type='int'),
-                             state=dict(type='str', choices=['present', 'absent'], default='present')
+                             state=dict(type='str', choices=['present', 'absent'], default='present'),
                          ),
                          allowed_vlans=dict(type='list', elements='str', default='all'),
                          poe_enabled=dict(type='bool', default=True),
@@ -521,8 +521,8 @@ def main():
         original = meraki.request(query_path, method='GET')
         # Check voiceVlan to see if state is absent to remove the vlan.
         if meraki.params.get('voice_vlan'):
-            if meraki.params.get('voice_vlan')['state'] == 'absent':
-                meraki.fail_json(msg='got to if', payload=meraki.params.get('voice_vlan'))
+            meraki.fail_json(msg='got to if', payload=type(meraki.params.get('voice_vlan')))
+            if meraki.params.get('voice_vlan')['state'] == 'absent': 
                 payload['voiceVlan'] = None
         if meraki.params.get('mac_allow_list'):
             macs = get_mac_list(original.get('macAllowList'), meraki.params["mac_allow_list"].get("macs"), meraki.params["mac_allow_list"].get("state"))

--- a/tests/integration/targets/meraki_switchport/tasks/main.yml
+++ b/tests/integration/targets/meraki_switchport/tasks/main.yml
@@ -199,8 +199,7 @@
     tags: desktop
     type: access
     vlan: 10
-    voice_vlan:
-      vlan: 12
+    voice_vlan: 12
   delegate_to: localhost
   register: update_port_vvlan
 
@@ -215,8 +214,7 @@
     tags: desktop
     type: access
     vlan: 10
-    voice_vlan:
-      vlan: 11
+    voice_vlan: 11
   delegate_to: localhost
   register: update_port_vvlan
 
@@ -239,8 +237,7 @@
     tags: desktop
     type: access
     vlan: 10
-    voice_vlan:
-      state: absent
+    voice_vlan_state: absent
   delegate_to: localhost
   register: update_port_remove_vvlan
 
@@ -263,8 +260,7 @@
     tags: desktop
     type: access
     vlan: 10
-    voice_vlan:
-      vlan: 11
+    voice_vlan: 11
   delegate_to: localhost
   register: update_port_access_idempotent
 

--- a/tests/integration/targets/meraki_switchport/tasks/main.yml
+++ b/tests/integration/targets/meraki_switchport/tasks/main.yml
@@ -246,7 +246,7 @@
 
 - assert:
     that:
-      - update_port_remove_vvlan.data.voice_vlan == null
+      - update_port_remove_vvlan.data.voice_vlan == None
       - update_port_remove_vvlan.changed == True
 
 - name: Check access port for idempotenty

--- a/tests/integration/targets/meraki_switchport/tasks/main.yml
+++ b/tests/integration/targets/meraki_switchport/tasks/main.yml
@@ -226,29 +226,6 @@
       - update_port_vvlan.data.voice_vlan == 11
       - update_port_vvlan.changed == True
 
-- name: Configure access port removing voice VLAN
-  meraki_switchport:
-    auth_key: '{{auth_key}}'
-    state: present
-    serial: '{{ serial_switch }}'
-    number: 7
-    enabled: true
-    name: Test Port
-    tags: desktop
-    type: access
-    vlan: 10
-    voice_vlan_state: absent
-  delegate_to: localhost
-  register: update_port_remove_vvlan
-
-- debug:
-    msg: '{{ update_port_remove_vvlan }}'
-
-- assert:
-    that:
-      - update_port_remove_vvlan.data.voice_vlan == None
-      - update_port_remove_vvlan.changed == True
-
 - name: Check access port for idempotenty
   meraki_switchport:
     auth_key: '{{auth_key}}'
@@ -271,6 +248,29 @@
     that:
       - update_port_access_idempotent.changed == False
       - update_port_access_idempotent.data is defined
+
+- name: Configure access port removing voice VLAN
+  meraki_switchport:
+    auth_key: '{{auth_key}}'
+    state: present
+    serial: '{{ serial_switch }}'
+    number: 7
+    enabled: true
+    name: Test Port
+    tags: desktop
+    type: access
+    vlan: 10
+    voice_vlan_state: absent
+  delegate_to: localhost
+  register: update_port_remove_vvlan
+
+- debug:
+    msg: '{{ update_port_remove_vvlan }}'
+
+- assert:
+    that:
+      - update_port_remove_vvlan.data.voice_vlan == None
+      - update_port_remove_vvlan.changed == True
 
 - name: Configure trunk port
   meraki_switchport:


### PR DESCRIPTION
fixes #238 

This allows the `state: absent` to be specified under `voice_vlan` in order to clear (null) out a voice vlan if it already exist.