### PR TITLE
Normalize L3 firewall protocol value case

### DIFF
--- a/plugins/modules/meraki_mr_l3_firewall.py
+++ b/plugins/modules/meraki_mr_l3_firewall.py
@@ -150,7 +150,16 @@ def get_rules(meraki, net_id, number):
     path = meraki.construct_path('get_all', net_id=net_id, custom={'number': number})
     response = meraki.request(path, method='GET')
     if meraki.status == 200:
-        return response
+        return normalize_protocol_case(response)
+
+
+def normalisze_protocol_case(rules):
+    try:
+        for r in rules['rules']:
+            r['protocol'] = r['protocol'].lower()
+    except KeyError:
+        return rules
+    return rules
 
 
 def get_ssid_number(name, data):

--- a/plugins/modules/meraki_mx_l3_firewall.py
+++ b/plugins/modules/meraki_mx_l3_firewall.py
@@ -224,8 +224,17 @@ def get_rules(meraki, net_id):
     path = meraki.construct_path('get_all', net_id=net_id)
     response = meraki.request(path, method='GET')
     if meraki.status == 200:
-        return response
+        return normalize_protocol_case(response)
 
+
+def normalisze_protocol_case(rules):
+    try:
+        for r in rules['rules']:
+            r['protocol'] = r['protocol'].lower()
+    except KeyError:
+        return rules
+    return rules
+    
 
 def normalize_case(rule):
     any = ['any', 'Any', 'ANY']


### PR DESCRIPTION
Merging existing and new firewall rules, https://docs.ansible.com/ansible/latest/scenario_guides/guide_meraki.html,  is currently not possible without manually changing the default rule's protocol value from `Any` to `any`. 

The default L3 firewall rule for MR and MX devices is:
`{"comment": "Default rule", "policy": "allow", "protocol": "Any", "dest_port": "Any", "dest_cidr": "Any"}`
The module parameter `protocol` only accepts `tcp, udp, icmp, any` in lowercase. The user-defined firewall rules are retrieved with the protocol value in lowercase. 

This PR normalizes the protocol value to lowercase for MR and MX devices **before** returning the data.