### PR TITLE
Normalize MR and MX default firewall rule protocol value

### DIFF
--- a/changelogs/fragments/lowercase-firewall-protocol.yml
+++ b/changelogs/fragments/lowercase-firewall-protocol.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - meraki_mr_l3_firewall - Return each MR L3 firewall rule's protocol value in lowercase.
+  - meraki_mx_l3_firewall - Return each MX L3 firewall rule's protocol value in lowercase.

--- a/changelogs/fragments/lowercase-firewall-protocol.yml
+++ b/changelogs/fragments/lowercase-firewall-protocol.yml
@@ -1,3 +1,0 @@
-minor_changes:
-  - meraki_mr_l3_firewall - Return each MR L3 firewall rule's protocol value in lowercase.
-  - meraki_mx_l3_firewall - Return each MX L3 firewall rule's protocol value in lowercase.

--- a/changelogs/fragments/lowercase-firewall-rule-values.yml
+++ b/changelogs/fragments/lowercase-firewall-rule-values.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - meraki_mr_l3_firewall - Return each MR L3 firewall rule's values in lowercase.
+  - meraki_mx_l3_firewall - Return each MX L3 firewall rule's values in lowercase.

--- a/plugins/modules/meraki_mr_l3_firewall.py
+++ b/plugins/modules/meraki_mr_l3_firewall.py
@@ -150,7 +150,16 @@ def get_rules(meraki, net_id, number):
     path = meraki.construct_path('get_all', net_id=net_id, custom={'number': number})
     response = meraki.request(path, method='GET')
     if meraki.status == 200:
-        return response
+        return normalize_protocol_case(response)
+
+
+def normalisze_protocol_case(rules):
+    try:
+        for r in rules['rules']:
+            r['protocol'] = r['protocol'].lower()
+    except KeyError:
+        return rules
+    return rules
 
 
 def get_ssid_number(name, data):

--- a/plugins/modules/meraki_mr_l3_firewall.py
+++ b/plugins/modules/meraki_mr_l3_firewall.py
@@ -153,7 +153,7 @@ def get_rules(meraki, net_id, number):
         return normalize_protocol_case(response)
 
 
-def normalisze_protocol_case(rules):
+def normalize_protocol_case(rules):
     try:
         for r in rules['rules']:
             r['protocol'] = r['protocol'].lower()

--- a/plugins/modules/meraki_mr_l3_firewall.py
+++ b/plugins/modules/meraki_mr_l3_firewall.py
@@ -150,13 +150,16 @@ def get_rules(meraki, net_id, number):
     path = meraki.construct_path('get_all', net_id=net_id, custom={'number': number})
     response = meraki.request(path, method='GET')
     if meraki.status == 200:
-        return normalize_protocol_case(response)
+        return normalize_case(response)
 
 
-def normalize_protocol_case(rules):
+def normalize_case(rules):
+    excluded = ['comment']
     try:
         for r in rules['rules']:
-            r['protocol'] = r['protocol'].lower()
+            for k in r:
+                if k not in excluded:
+                    r[k] = r[k].lower()
     except KeyError:
         return rules
     return rules

--- a/plugins/modules/meraki_mr_l3_firewall.py
+++ b/plugins/modules/meraki_mr_l3_firewall.py
@@ -150,10 +150,10 @@ def get_rules(meraki, net_id, number):
     path = meraki.construct_path('get_all', net_id=net_id, custom={'number': number})
     response = meraki.request(path, method='GET')
     if meraki.status == 200:
-        return normalize_case(response)
+        return normalize_rule_case(response)
 
 
-def normalize_case(rules):
+def normalize_rule_case(rules):
     excluded = ['comment']
     try:
         for r in rules['rules']:

--- a/plugins/modules/meraki_mx_l3_firewall.py
+++ b/plugins/modules/meraki_mx_l3_firewall.py
@@ -224,13 +224,16 @@ def get_rules(meraki, net_id):
     path = meraki.construct_path('get_all', net_id=net_id)
     response = meraki.request(path, method='GET')
     if meraki.status == 200:
-        return normalize_protocol_case(response)
+        return normalize_rule_case(response)
 
 
-def normalize_protocol_case(rules):
+def normalize_rule_case(rules):
+    excluded = ['comment', 'syslogEnabled']
     try:
         for r in rules['rules']:
-            r['protocol'] = r['protocol'].lower()
+            for k in r:
+                if k not in excluded:
+                    r[k] = r[k].lower()
     except KeyError:
         return rules
     return rules

--- a/plugins/modules/meraki_mx_l3_firewall.py
+++ b/plugins/modules/meraki_mx_l3_firewall.py
@@ -227,7 +227,7 @@ def get_rules(meraki, net_id):
         return normalize_protocol_case(response)
 
 
-def normalisze_protocol_case(rules):
+def normalize_protocol_case(rules):
     try:
         for r in rules['rules']:
             r['protocol'] = r['protocol'].lower()

--- a/plugins/modules/meraki_mx_l3_firewall.py
+++ b/plugins/modules/meraki_mx_l3_firewall.py
@@ -224,8 +224,17 @@ def get_rules(meraki, net_id):
     path = meraki.construct_path('get_all', net_id=net_id)
     response = meraki.request(path, method='GET')
     if meraki.status == 200:
-        return response
+        return normalize_protocol_case(response)
 
+
+def normalisze_protocol_case(rules):
+    try:
+        for r in rules['rules']:
+            r['protocol'] = r['protocol'].lower()
+    except KeyError:
+        return rules
+    return rules
+    
 
 def normalize_case(rule):
     any = ['any', 'Any', 'ANY']

--- a/tests/integration/targets/meraki_mr_l3_firewall/tasks/main.yml
+++ b/tests/integration/targets/meraki_mr_l3_firewall/tasks/main.yml
@@ -17,6 +17,20 @@
   - set_fact:
       net: '{{new_net.data.id}}'
 
+  - name: Check default rules protocol values are lowercase
+    meraki_mx_l3_firewall:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{test_org_name}}'
+      net_name: TestNetAppliance
+      state: query
+    delegate_to: localhost
+    register: query
+    
+  - assert:
+      that:
+        - query.data.0.protocol == 'any'
+        - query.data.1.protocol == 'any'
+
   - name: Create single firewall rule with check mode
     meraki_mr_l3_firewall:
       auth_key: '{{ auth_key }}'

--- a/tests/integration/targets/meraki_mr_l3_firewall/tasks/main.yml
+++ b/tests/integration/targets/meraki_mr_l3_firewall/tasks/main.yml
@@ -17,7 +17,7 @@
   - set_fact:
       net: '{{new_net.data.id}}'
 
-  - name: Check default rules protocol values are lowercase
+  - name: Check rule values are lowercase
     meraki_mr_l3_firewall:
       auth_key: '{{ auth_key }}'
       org_name: '{{test_org_name}}'
@@ -28,8 +28,16 @@
     
   - assert:
       that:
+        - query.data.rules.0.policy == 'allow'
         - query.data.rules.0.protocol == 'any'
+        - query.data.rules.0.dest_port == 'any'
+        - query.data.rules.0.dest_cidr == 'local lan'
+        - query.data.rules.0.comment == 'Wireless clients accessing LAN'
+        - query.data.rules.1.policy == 'allow'
         - query.data.rules.1.protocol == 'any'
+        - query.data.rules.1.dest_port == 'any'
+        - query.data.rules.1.dest_cidr == 'any'
+        - query.data.rules.1.comment == 'Default rule'
 
   - name: Create single firewall rule with check mode
     meraki_mr_l3_firewall:

--- a/tests/integration/targets/meraki_mr_l3_firewall/tasks/main.yml
+++ b/tests/integration/targets/meraki_mr_l3_firewall/tasks/main.yml
@@ -28,8 +28,8 @@
     
   - assert:
       that:
-        - query.data.0.protocol == 'any'
-        - query.data.1.protocol == 'any'
+        - query.data.rules.0.protocol == 'any'
+        - query.data.rules.1.protocol == 'any'
 
   - name: Create single firewall rule with check mode
     meraki_mr_l3_firewall:

--- a/tests/integration/targets/meraki_mr_l3_firewall/tasks/main.yml
+++ b/tests/integration/targets/meraki_mr_l3_firewall/tasks/main.yml
@@ -18,7 +18,7 @@
       net: '{{new_net.data.id}}'
 
   - name: Check default rules protocol values are lowercase
-    meraki_mx_l3_firewall:
+    meraki_mr_l3_firewall:
       auth_key: '{{ auth_key }}'
       org_name: '{{test_org_name}}'
       net_name: TestNetAppliance

--- a/tests/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
+++ b/tests/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
@@ -31,7 +31,7 @@
       that:
         - query.data|length == 1
         
-  - name: Check default rule protocol value is lowercase
+  - name: Check rule values are lowercase
     meraki_mx_l3_firewall:
       auth_key: '{{ auth_key }}'
       org_name: '{{test_org_name}}'
@@ -42,7 +42,12 @@
     
   - assert:
       that:
+        - query.data.rules.0.policy == 'allow'
         - query.data.rules.0.protocol == 'any'
+        - query.data.rules.0.src_port == 'any'
+        - query.data.rules.0.src_cidr == 'any'
+        - query.data.rules.0.dest_port == 'any'
+        - query.data.rules.0.dest_cidr == 'any'
 
   - name: Set one firewall rule with check mode
     meraki_mx_l3_firewall:

--- a/tests/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
+++ b/tests/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
@@ -30,6 +30,19 @@
   - assert:
       that:
         - query.data|length == 1
+        
+  - name: Check default rule protocol value is lowercase
+    meraki_mx_l3_firewall:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{test_org_name}}'
+      net_name: TestNetAppliance
+      state: query
+    delegate_to: localhost
+    register: query
+    
+  - assert:
+      that:
+        - query.data.0.protocol == 'any'
 
   - name: Set one firewall rule with check mode
     meraki_mx_l3_firewall:

--- a/tests/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
+++ b/tests/integration/targets/meraki_mx_l3_firewall/tasks/main.yml
@@ -42,7 +42,7 @@
     
   - assert:
       that:
-        - query.data.0.protocol == 'any'
+        - query.data.rules.0.protocol == 'any'
 
   - name: Set one firewall rule with check mode
     meraki_mx_l3_firewall:


### PR DESCRIPTION
The MR and MX default firewall rule is returned with the value of protocol capitalized as `Any` while the user-defined firewall rules are returned with the value of protocol in all lowercase such as `any`.

The default MR L3 firewall rules are:
`{"comment": "Wireless clients accessing LAN", "policy": "allow", "protocol": "Any", "dest_port": "Any", "dest_cdr": "Local LAN"}`
`{"comment": "Default rule", "policy": "allow", "protocol": "Any", "dest_port": "Any", "dest_cdr": "Any"}`

The default MX L3 firewall rule is:
`{"comment": "Default rule", "policy": "allow", "protocol": "Any", "dest_port": "Any", "dest_cdr": "Any"}`

When attempting to merge existing and new firewall rules, https://docs.ansible.com/ansible/latest/scenario_guides/guide_meraki.html#merging-existing-and-new-data, the MR and MX firewall modules return an error for the `Default rule(s)` as it is returned to the user as `Any` and the protocol parameter only accepts values in lowercase `tcp, udp, icmp, any`.  The user should not have to manipulate data retrieved from these modules before merging or altering the rules and attempting to supply the values back.  This PR normalizes the protocol value to be lowercase before returning it to the user.