### PR TITLE
Update CICD job to use Python 3.8 instead of 3.6

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -14,10 +14,10 @@ jobs:
         with:
           path: ansible_collections/cisco/meraki
 
-      - name: Set up Python 3.6
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.8
 
       - name: Install ansible-base (devel)
         run: pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check


### PR DESCRIPTION
Ansible is now using Python 3.8 as a minimum version. This PR upgrades to match the requirement.