### PR TITLE
Add diff output for ms switchport

### DIFF
--- a/plugins/modules/meraki_ms_switchport.py
+++ b/plugins/modules/meraki_ms_switchport.py
@@ -574,7 +574,9 @@ def main():
             proposed['voiceVlan'] = original['voiceVlan']  # API shouldn't include voice VLAN on a trunk port
         # meraki.fail_json(msg='Compare', original=original, payload=payload)
         if meraki.is_update_required(original, proposed, optional_ignore=['number']):
-            meraki.generate_diff(original, payload)
+            original_stripped = {k: v for k, v in original.items() if v is not None}
+            payload_stripped = {k: v for k, v in payload.items() if v is not None}
+            meraki.generate_diff(original_stripped, payload_stripped)
             if meraki.check_mode is True:
                 original.update(proposed)
                 meraki.result['data'] = original
@@ -587,7 +589,7 @@ def main():
             response = meraki.request(path, method='PUT', payload=json.dumps(payload))
             meraki.result['data'] = response
             meraki.result['changed'] = True
-            meraki.generate_diff(original, response)
+            meraki.generate_diff(original_stripped, response)
         else:
             meraki.result['data'] = original
 


### PR DESCRIPTION
For some reason, you didn't include diff output for `meraki_ms_switchport`.
Is it ok if we add it back, please?

It's really useful to see what changes will be applied to switchports.