### PR TITLE
meraki_mx_l7_firewall - Delete rules with empty ruleset

### DIFF
--- a/changelogs/fragments/mx_l7_firewall_empty_list.yaml
+++ b/changelogs/fragments/mx_l7_firewall_empty_list.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - meraki_mx_l7_firewall - Allow passing an empty ruleset to delete all rules
+  - meraki_utils - Add debugging output for failed socket connections

--- a/plugins/module_utils/network/meraki/meraki.py
+++ b/plugins/module_utils/network/meraki/meraki.py
@@ -157,9 +157,12 @@ class MerakiModule(object):
         elif isinstance(data, int) or isinstance(data, str) or isinstance(data, float):
             return data
 
-    def is_update_required(self, original, proposed, optional_ignore=None, debug=False):
+    def is_update_required(self, original, proposed, optional_ignore=None, force_include=None, debug=False):
         ''' Compare two data-structures '''
         self.ignored_keys.append('net_id')
+        if force_include is not None:
+            if force_include in self.ignored_keys:
+                self.ignored_keys.remove(force_include)
         if optional_ignore is not None:
             # self.fail_json(msg="Keys", ignored_keys=self.ignored_keys, optional=optional_ignore)
             self.ignored_keys = self.ignored_keys + optional_ignore
@@ -458,7 +461,14 @@ class MerakiModule(object):
             data = None
             if 'body' in info:
                 self.body = info['body']
-            data = json.loads(to_native(resp.read()))
+            try:
+                data = json.loads(to_native(resp.read()))
+            except AttributeError:
+                self.fail_json(msg="Failure occurred during pagination",
+                               response=self.response,
+                               status=self.status,
+                               body=self.body
+                               )
             header_link = self._parse_pagination_header(info['link'])
             while header_link['next'] is not None:
                 self.url = header_link['next']
@@ -468,7 +478,14 @@ class MerakiModule(object):
                 except HTTPError:
                     self.fail_json(msg="HTTP request to {url} failed with error code {code}".format(url=self.url, code=self.status))
                 header_link = self._parse_pagination_header(info['link'])
-                data.extend(json.loads(to_native(resp.read())))
+                try:
+                    data.extend(json.loads(to_native(resp.read())))
+                except AttributeError:
+                    self.fail_json(msg="Failure occurred during pagination",
+                                   response=self.response,
+                                   status=self.status,
+                                   body=self.body
+                                   )
             return data
         else:  # Non-pagination
             if 'body' in info:
@@ -477,6 +494,12 @@ class MerakiModule(object):
                 return json.loads(to_native(resp.read()))
             except json.decoder.JSONDecodeError:
                 return {}
+            except AttributeError:
+                self.fail_json(msg="Failure occurred",
+                               response=self.response,
+                               status=self.status,
+                               body=self.body
+                               )
 
     def exit_json(self, **kwargs):
         """Custom written method to exit from module."""

--- a/plugins/modules/meraki_mx_l7_firewall.py
+++ b/plugins/modules/meraki_mx_l7_firewall.py
@@ -446,7 +446,7 @@ def main():
                 payload['rules'].append(assemble_payload(meraki, net_id, rule))
         else:
             payload = dict()
-        if meraki.is_update_required(rules,payload, force_include='id'):
+        if meraki.is_update_required(rules, payload, force_include='id'):
             if meraki.module.check_mode is True:
                 response = restructure_response(payload)
                 meraki.generate_diff(restructure_response(rules), response)

--- a/plugins/modules/meraki_mx_l7_firewall.py
+++ b/plugins/modules/meraki_mx_l7_firewall.py
@@ -422,7 +422,12 @@ def main():
 
         # Detect if no rules are given, special case
         if len(meraki.params['rules']) == 0:
-            if meraki.is_update_required(rules, meraki.params['rules']):
+            # Conditionally wrap parameters in rules makes it comparable
+            if isinstance(meraki.params['rules'], list):
+                param_rules = {'rules': meraki.params['rules']}
+            else:
+                param_rules = meraki.params['rules']
+            if meraki.is_update_required(rules, param_rules):
                 if meraki.module.check_mode is True:
                     meraki.result['data'] = meraki.params['rules']
                     meraki.result['changed'] = True
@@ -433,7 +438,7 @@ def main():
                 meraki.result['changed'] = True
                 meraki.exit_json(**meraki.result)
             else:
-                meraki.result['data'] = meraki.params['rules']
+                meraki.result['data'] = param_rules
                 meraki.exit_json(**meraki.result)
         if meraki.params['rules']:
             payload = {'rules': []}

--- a/tests/integration/targets/meraki_mx_l7_firewall/tasks/tests.yml
+++ b/tests/integration/targets/meraki_mx_l7_firewall/tasks/tests.yml
@@ -25,9 +25,6 @@
       state: query
     register: query
 
-  - debug:
-      var: query
-
   - assert:
       that:
         - query.data is defined
@@ -44,6 +41,39 @@
   - assert:
       that:
         - query_categories.data is defined
+
+  - name: Set firewall rules to empty array
+    meraki_mx_l7_firewall:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{test_org_name}}'
+      net_name: TestNetAppliance
+      state: present
+      rules: []
+    register: empty_list
+
+  - debug:
+      var: empty_list
+
+  - assert:
+      that:
+        - empty_list.data.rules | length == 0
+
+  - name: Set firewall rules to empty array with idempotency
+    meraki_mx_l7_firewall:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{test_org_name}}'
+      net_name: TestNetAppliance
+      state: present
+      rules: []
+    register: empty_list_idempotent
+
+  - debug:
+      var: empty_list_idempotent
+
+  - assert:
+      that:
+        - empty_list_idempotent.data.rules | length == 0
+        - empty_list_idempotent is not changed
 
   - name: Create firewall rule for IP range in check mode
     meraki_mx_l7_firewall:

--- a/tests/integration/targets/meraki_mx_l7_firewall/tasks/tests.yml
+++ b/tests/integration/targets/meraki_mx_l7_firewall/tasks/tests.yml
@@ -4,59 +4,59 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
 - block:
-  - name: Test an API key is provided
-    fail:
-      msg: Please define an API key
-    when: auth_key is not defined
+  # - name: Test an API key is provided
+  #   fail:
+  #     msg: Please define an API key
+  #   when: auth_key is not defined
     
-  - name: Create network
-    meraki_network:
-      auth_key: '{{ auth_key }}'
-      org_name: '{{test_org_name}}'
-      net_name: TestNetAppliance
-      state: present
-      type: appliance
+  # - name: Create network
+  #   meraki_network:
+  #     auth_key: '{{ auth_key }}'
+  #     org_name: '{{test_org_name}}'
+  #     net_name: TestNetAppliance
+  #     state: present
+  #     type: appliance
 
-  - name: Query firewall rules
-    meraki_mx_l7_firewall:
-      auth_key: '{{ auth_key }}'
-      org_name: '{{test_org_name}}'
-      net_name: TestNetAppliance
-      state: query
-    register: query
+  # - name: Query firewall rules
+  #   meraki_mx_l7_firewall:
+  #     auth_key: '{{ auth_key }}'
+  #     org_name: '{{test_org_name}}'
+  #     net_name: TestNetAppliance
+  #     state: query
+  #   register: query
 
-  - assert:
-      that:
-        - query.data is defined
+  # - assert:
+  #     that:
+  #       - query.data is defined
 
-  - name: Query firewall application categories
-    meraki_mx_l7_firewall:
-      auth_key: '{{ auth_key }}'
-      org_name: '{{test_org_name}}'
-      net_name: TestNetAppliance
-      state: query
-      categories: yes
-    register: query_categories
+  # - name: Query firewall application categories
+  #   meraki_mx_l7_firewall:
+  #     auth_key: '{{ auth_key }}'
+  #     org_name: '{{test_org_name}}'
+  #     net_name: TestNetAppliance
+  #     state: query
+  #     categories: yes
+  #   register: query_categories
 
-  - assert:
-      that:
-        - query_categories.data is defined
+  # - assert:
+  #     that:
+  #       - query_categories.data is defined
 
-  - name: Set firewall rules to empty array
-    meraki_mx_l7_firewall:
-      auth_key: '{{ auth_key }}'
-      org_name: '{{test_org_name}}'
-      net_name: TestNetAppliance
-      state: present
-      rules: []
-    register: empty_list
+  # - name: Set firewall rules to empty array
+  #   meraki_mx_l7_firewall:
+  #     auth_key: '{{ auth_key }}'
+  #     org_name: '{{test_org_name}}'
+  #     net_name: TestNetAppliance
+  #     state: present
+  #     rules: []
+  #   register: empty_list
 
-  - debug:
-      var: empty_list
+  # - debug:
+  #     var: empty_list
 
-  - assert:
-      that:
-        - empty_list.data.rules | length == 0
+  # - assert:
+  #     that:
+  #       - empty_list.data.rules | length == 0
 
   - name: Set firewall rules to empty array with idempotency
     meraki_mx_l7_firewall:


### PR DESCRIPTION
This PR will delete rules when an empty ruleset is provided for `rules` and `state: present`. As of now, there is no `state: absent` function but that may come in a future version as I can see how that can be useful for removing individual rules.

This also improves error handling for when Ansible returns no response. Currently it fails but will eventually retry.

Fixes #257 