### PR TITLE
Add handling of failed requests

### DIFF
--- a/changelogs/fragments/nonetype-request.yaml
+++ b/changelogs/fragments/nonetype-request.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Requests failing due to local socket problems will be handled and retried.

--- a/plugins/module_utils/network/meraki/meraki.py
+++ b/plugins/module_utils/network/meraki/meraki.py
@@ -477,6 +477,12 @@ class MerakiModule(object):
                 return json.loads(to_native(resp.read()))
             except json.decoder.JSONDecodeError:
                 return {}
+            except AttributeError:
+                if self.retry == 5:
+                    self.fail_json(msg='Request failed 5 times. Exiting.')
+                self.module.warn("Error. Retrying {self.retry}/5.")
+                self.retry += 1
+                resp, info = self._execute_request(path, method=method, payload=payload, params=params)
 
     def exit_json(self, **kwargs):
         """Custom written method to exit from module."""


### PR DESCRIPTION
Socket errors sometimes happen when making requests. The situation wasn't handled so I am now catching it. It will retry 5 times before failing. Fixes #250 