### PR TITLE
Fix issue with SSID removal idempotency when ID doesn't exist

### DIFF
--- a/changelogs/fragments/delete-ssid-idempotency.yml
+++ b/changelogs/fragments/delete-ssid-idempotency.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - meraki_mr_ssid - Fix issue with SSID removal idempotency when ID doesn't exist

--- a/plugins/modules/meraki_mr_ssid.py
+++ b/plugins/modules/meraki_mr_ssid.py
@@ -597,9 +597,14 @@ def main():
         if ssid_id is None:  # Name should be used to lookup number
             ssid_id = get_ssid_number(meraki.params['name'], ssids)
             if ssid_id is False:
+                # This will return True as long as there's an unclaimed SSID number!
                 ssid_id = get_available_number(ssids)
+                # There are no available SSIDs or SSID numbers
                 if ssid_id is False:
-                    meraki.fail_json(msg='No SSID found by specified name and no number was referenced.')
+                    meraki.fail_json(msg='No SSID found by specified name and no numbers unclaimed.')
+                meraki.result['changed'] = False
+                meraki.result['data'] = {}
+                meraki.exit_json(**meraki.result)
         if meraki.check_mode is True:
             meraki.result['data'] = {}
             meraki.result['changed'] = True

--- a/tests/integration/targets/meraki_ssid/tasks/main.yml
+++ b/tests/integration/targets/meraki_ssid/tasks/main.yml
@@ -527,7 +527,7 @@
 
   - assert:
       that:
-        - delete_ssid is changed
+        - deleted_ssid is changed
 
   - name: Remove SSID to Test SSID Delete Idempotency
     meraki_ssid:
@@ -541,7 +541,7 @@
 
   - assert:
       that:
-        - delete_ssid is not changed
+        - deleted_ssid is not changed
 
   always:
   - name: Delete SSID with check mode

--- a/tests/integration/targets/meraki_ssid/tasks/main.yml
+++ b/tests/integration/targets/meraki_ssid/tasks/main.yml
@@ -505,6 +505,44 @@
       that: 
         - 'set_vlan_arg_err.msg == "default_vlan_id is required when use_vlan_tagging is True"'
 
+  - name: Create SSID to Test SSID Delete Idempotency
+    meraki_ssid:
+      auth_key: '{{auth_key}}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: TestNetSSID
+      name: AnsibleIdempotentDeleteSSID
+      enabled: true
+    delegate_to: localhost
+
+  - name: Remove SSID to Test SSID Delete Idempotency
+    meraki_ssid:
+      auth_key: '{{auth_key}}'
+      state: absent
+      org_name: '{{test_org_name}}'
+      net_name: TestNetSSID
+      name: AnsibleIdempotentDeleteSSID
+    delegate_to: localhost
+    register: deleted_ssid
+
+  - assert:
+      that:
+        - delete_ssid is changed
+
+  - name: Remove SSID to Test SSID Delete Idempotency
+    meraki_ssid:
+      auth_key: '{{auth_key}}'
+      state: absent
+      org_name: '{{test_org_name}}'
+      net_name: TestNetSSID
+      name: AnsibleIdempotentDeleteSSID
+    delegate_to: localhost
+    register: deleted_ssid
+
+  - assert:
+      that:
+        - delete_ssid is not changed
+
   always:
   - name: Delete SSID with check mode
     meraki_ssid:


### PR DESCRIPTION
When deleting an SSID by name, the `meraki_mr_ssid` module does not current return the expected results.  `get_available_number()` will always return a truthy value as long as there is a free SSID number available.  This ultimately results in `meraki.result.changed` always being `True`, even when no SSID would be deleted.  The bevahior can be reproduced with the following task:

```yaml
- name: Remove Default SSID
  cisco.meraki.meraki_mr_ssid:
    org_id: "{{ meraki_org_id }}"
    net_name: "{{ meraki_net_name }}"
    name: "{{ meraki_net_name }} WiFi"
    state: absent
```

Running the task above more than once will result in Ansible reporting a change, even though the SSID no longer exists.

To fix the issue, this MR leaves the existing logic intact but adds an early exit and sets `meraki.result.changed` to `False` when:

* `ssid_id` is None
* An `ssid_id` cannot be derived from a name using `get_ssid_number()`