### PR TITLE
Fix issue with RF Profile creation when using name

### DIFF
--- a/changelogs/fragments/rf-profile-create-idempotency.yml
+++ b/changelogs/fragments/rf-profile-create-idempotency.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - meraki_mr_rf_profile - Fix issue with idempotency and creation of RF Profiles by name only

--- a/plugins/modules/meraki_mr_rf_profile.py
+++ b/plugins/modules/meraki_mr_rf_profile.py
@@ -601,6 +601,7 @@ def main():
         path = meraki.construct_path('get_all', net_id=net_id)
         profiles = meraki.request(path, method='GET')
         # profile = get_profile(meraki, profiles, meraki.params['name'])
+        profile_id = next((profile['id'] for profile in profiles if profile['name'] == meraki.params['name']), None)
 
     if meraki.params['state'] == 'query':
         if profile_id is not None:

--- a/tests/integration/targets/meraki_mr_rf_profile/tasks/main.yml
+++ b/tests/integration/targets/meraki_mr_rf_profile/tasks/main.yml
@@ -276,7 +276,7 @@
     - assert:
         that:
           - create_281.data is defined
-          - create_281.data is changed
+          - create_281 is changed
     - name: Create RF Profile - Idempotent
       cisco.meraki.meraki_mr_rf_profile:
         auth_key: '{{ auth_key }}'
@@ -295,7 +295,7 @@
     - assert:
         that:
           - idempotent_281.data is defined
-          - idempotent_281.data is not changed
+          - idempotent_281 is not changed
     - name: Clean Up RF Profile
       cisco.meraki.meraki_mr_rf_profile:
         auth_key: '{{ auth_key }}'
@@ -307,7 +307,7 @@
     - assert:
         that:
           - delete_281.data is defined
-          - delete_281.data is changed
+          - delete_281 is changed
 
 #############################################################################
 # Tear down starts here

--- a/tests/integration/targets/meraki_mr_rf_profile/tasks/main.yml
+++ b/tests/integration/targets/meraki_mr_rf_profile/tasks/main.yml
@@ -256,6 +256,58 @@
       that:
         - delete.data is defined
         - delete is changed
+- name: "Test RFProfile Bugfix from !281"
+  block:
+    - name: Create RF Profile
+      cisco.meraki.meraki_mr_rf_profile:
+        auth_key: '{{ auth_key }}'
+        org_name: '{{test_org_name}}'
+        net_name: IntTestNetworkWireless
+        name: "RF Profile - !281"
+        band_selection_type: ap
+        ap_band_settings:
+          mode: 'dual'
+        five_ghz_settings:
+          channel_width: 40
+        two_four_ghz_settings:
+          ax_enabled: 'no'
+        state: present
+      register: create_281
+    - assert:
+        that:
+          - create_281.data is defined
+          - create_281.data is changed
+    - name: Create RF Profile - Idempotent
+      cisco.meraki.meraki_mr_rf_profile:
+        auth_key: '{{ auth_key }}'
+        org_name: '{{test_org_name}}'
+        net_name: IntTestNetworkWireless
+        name: "RF Profile - !281"
+        band_selection_type: ap
+        ap_band_settings:
+          mode: 'dual'
+        five_ghz_settings:
+          channel_width: 40
+        two_four_ghz_settings:
+          ax_enabled: 'no'
+        state: present
+      register: idempotent_281
+    - assert:
+        that:
+          - idempotent_281.data is defined
+          - idempotent_281.data is not changed
+    - name: Clean Up RF Profile
+      cisco.meraki.meraki_mr_rf_profile:
+        auth_key: '{{ auth_key }}'
+        org_name: '{{test_org_name}}'
+        net_name: IntTestNetworkWireless
+        name: "RF Profile - !281"
+        state: absent
+      register: delete_281
+    - assert:
+        that:
+          - delete_281.data is defined
+          - delete_281.data is changed
 
 #############################################################################
 # Tear down starts here


### PR DESCRIPTION
The check for `profile_id` doesn't set a `profile_id` if one could be derived from the name.  This results in creating an RF Profile by name always reporting a change in check mode or an error when trying to `POST`.  This can be reproduced with a task similar to the following:

```yaml
- name: Create RF Profiles
  cisco.meraki.meraki_mr_rf_profile:
    org_id: "{{ meraki_org_id }}"
    net_name: "{{ meraki_net_name }}"
    name: "Example RF Profile"
    band_selection_type: ap
    ap_band_settings:
        mode: 'dual'
    five_ghz_settings:
      channel_width: 40
    two_four_ghz_settings:
      ax_enabled: 'no'
    state: present
```

This PR fixes the issue by attempting to derive the profile ID from the profile name, falling back to `None` when a profile by the given name doesn't exist (which should preserve the rest of the behaviors later).