### PR TITLE
meraki_syslog - Fix crash with out of order roles

### DIFF
--- a/changelogs/fragments/288-syslog_idempotency.yml
+++ b/changelogs/fragments/288-syslog_idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - meraki_syslog - Improve reliability for multiple roles or capitalization.

--- a/changelogs/fragments/rf-profile-create-idempotency.yml
+++ b/changelogs/fragments/rf-profile-create-idempotency.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - meraki_mr_rf_profile - Fix issue with idempotency and creation of RF Profiles by name only

--- a/plugins/modules/meraki_mr_rf_profile.py
+++ b/plugins/modules/meraki_mr_rf_profile.py
@@ -601,6 +601,7 @@ def main():
         path = meraki.construct_path('get_all', net_id=net_id)
         profiles = meraki.request(path, method='GET')
         # profile = get_profile(meraki, profiles, meraki.params['name'])
+        profile_id = next((profile['id'] for profile in profiles if profile['name'] == meraki.params['name']), None)
 
     if meraki.params['state'] == 'query':
         if profile_id is not None:

--- a/plugins/modules/meraki_syslog.py
+++ b/plugins/modules/meraki_syslog.py
@@ -62,7 +62,7 @@ options:
             roles:
                 description:
                 - List of applicable Syslog server roles.
-                - Choices are one of the following case insensitive options: 'Wireless Event log', 'Appliance event log', 'Switch event log', 'Air Marshal events', 'Flows', 'URLs', 'IDS alerts', 'Security events'
+                - Choices can be one of Wireless Event log, Appliance event log, Switch event log, Air Marshal events, Flows, URLs, IDS alerts, Security events
                 type: list
                 elements: str
 

--- a/plugins/modules/meraki_syslog.py
+++ b/plugins/modules/meraki_syslog.py
@@ -177,7 +177,7 @@ def validate_role_choices(meraki, servers):
         for role in servers[server]["roles"]:
             if role.lower() not in choices:
                 meraki.fail_json(
-                    msg=f"Invalid role found in {servers[server]['host']}."
+                    msg="Invalid role found in {}.".format(servers[server]["host"])
                 )
 
 

--- a/plugins/modules/meraki_syslog.py
+++ b/plugins/modules/meraki_syslog.py
@@ -177,7 +177,7 @@ def validate_role_choices(meraki, servers):
         for role in servers[server]["roles"]:
             if role.lower() not in choices:
                 meraki.fail_json(
-                    msg="Invalid role found in {}.".format(servers[server]["host"])
+                    msg="Invalid role found in {0}.".format(servers[server]["host"])
                 )
 
 

--- a/plugins/modules/meraki_syslog.py
+++ b/plugins/modules/meraki_syslog.py
@@ -62,14 +62,7 @@ options:
             roles:
                 description:
                 - List of applicable Syslog server roles.
-                choices: ['Wireless Event log',
-                          'Appliance event log',
-                          'Switch event log',
-                          'Air Marshal events',
-                          'Flows',
-                          'URLs',
-                          'IDS alerts',
-                          'Security events']
+                - Choices are one of the following case insensitive options: 'Wireless Event log', 'Appliance event log', 'Switch event log', 'Air Marshal events', 'Flows', 'URLs', 'IDS alerts', 'Security events'
                 type: list
                 elements: str
 

--- a/plugins/modules/meraki_syslog.py
+++ b/plugins/modules/meraki_syslog.py
@@ -5,15 +5,16 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
 ANSIBLE_METADATA = {
-    'metadata_version': '1.1',
-    'status': ['preview'],
-    'supported_by': 'community'
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
 }
 
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
 ---
 module: meraki_syslog
 short_description: Manage syslog server settings in the Meraki cloud.
@@ -75,9 +76,9 @@ options:
 author:
     - Kevin Breit (@kbreit)
 extends_documentation_fragment: cisco.meraki.meraki
-'''
+"""
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: Query syslog configurations on network named MyNet in the YourOrg organization
   meraki_syslog:
     auth_key: abc12345
@@ -116,9 +117,9 @@ EXAMPLES = r'''
           - Appliance event log
           - Flows
   delegate_to: localhost
-'''
+"""
 
-RETURN = r'''
+RETURN = r"""
 data:
     description: Information about the created or manipulated object.
     returned: info
@@ -144,10 +145,24 @@ data:
             returned: success
             type: list
             sample: "Wireless event log, URLs"
-'''
+"""
 
+from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule, json
-from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import MerakiModule, meraki_argument_spec
+from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import (
+    MerakiModule,
+    meraki_argument_spec,
+)
+
+
+def sort_roles(syslog_servers):
+    """Accept a full payload and sort roles"""
+    # sorted_servers = list()
+    for i, server in enumerate(syslog_servers):
+        syslog_servers["servers"][i]["roles"] = sorted(
+            syslog_servers["servers"][i]["roles"]
+        )
+    # return sorted_servers
 
 
 def main():
@@ -155,48 +170,58 @@ def main():
     # define the available arguments/parameters that a user can pass to
     # the module
 
-    server_arg_spec = dict(host=dict(type='str'),
-                           port=dict(type='int', default="514"),
-                           roles=dict(type='list', elements='str', choices=['Wireless Event log',
-                                                                            'Appliance event log',
-                                                                            'Switch event log',
-                                                                            'Air Marshal events',
-                                                                            'Flows',
-                                                                            'URLs',
-                                                                            'IDS alerts',
-                                                                            'Security events',
-                                                                            ]),
-                           )
+    server_arg_spec = dict(
+        host=dict(type="str"),
+        port=dict(type="int", default="514"),
+        roles=dict(
+            type="list",
+            elements="str",
+            choices=[
+                "Wireless Event log",
+                "Appliance event log",
+                "Switch event log",
+                "Air Marshal events",
+                "Flows",
+                "URLs",
+                "IDS alerts",
+                "Security events",
+            ],
+        ),
+    )
 
     argument_spec = meraki_argument_spec()
-    argument_spec.update(net_id=dict(type='str'),
-                         servers=dict(type='list', elements='dict', options=server_arg_spec),
-                         state=dict(type='str', choices=['present', 'query'], default='present'),
-                         net_name=dict(type='str', aliases=['name', 'network']),
-                         )
+    argument_spec.update(
+        net_id=dict(type="str"),
+        servers=dict(type="list", elements="dict", options=server_arg_spec),
+        state=dict(type="str", choices=["present", "query"], default="present"),
+        net_name=dict(type="str", aliases=["name", "network"]),
+    )
 
     # the AnsibleModule object will be our abstraction working with Ansible
     # this includes instantiation, a couple of common attr would be the
     # args/params passed to the execution, as well as if the module
     # supports check mode
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True,
-                           )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
 
-    meraki = MerakiModule(module, function='syslog')
-    module.params['follow_redirects'] = 'all'
+    meraki = MerakiModule(module, function="syslog")
+    module.params["follow_redirects"] = "all"
     payload = None
 
-    syslog_urls = {'syslog': '/networks/{net_id}/syslogServers'}
-    meraki.url_catalog['query_update'] = syslog_urls
+    syslog_urls = {"syslog": "/networks/{net_id}/syslogServers"}
+    meraki.url_catalog["query_update"] = syslog_urls
 
-    if not meraki.params['org_name'] and not meraki.params['org_id']:
-        meraki.fail_json(msg='org_name or org_id parameters are required')
-    if meraki.params['state'] != 'query':
-        if not meraki.params['net_name'] and not meraki.params['net_id']:
-            meraki.fail_json(msg='net_name or net_id is required for present or absent states')
-    if meraki.params['net_name'] and meraki.params['net_id']:
-        meraki.fail_json(msg='net_name and net_id are mutually exclusive')
+    if not meraki.params["org_name"] and not meraki.params["org_id"]:
+        meraki.fail_json(msg="org_name or org_id parameters are required")
+    if meraki.params["state"] != "query":
+        if not meraki.params["net_name"] and not meraki.params["net_id"]:
+            meraki.fail_json(
+                msg="net_name or net_id is required for present or absent states"
+            )
+    if meraki.params["net_name"] and meraki.params["net_id"]:
+        meraki.fail_json(msg="net_name and net_id are mutually exclusive")
 
     # if the user is working with this module in only check mode we do not
     # want to make any changes to the environment, just return the current
@@ -205,56 +230,65 @@ def main():
     # manipulate or modify the state as needed (this is going to be the
     # part where your module will do what it needs to do)
 
-    org_id = meraki.params['org_id']
+    org_id = meraki.params["org_id"]
     if not org_id:
-        org_id = meraki.get_org_id(meraki.params['org_name'])
-    net_id = meraki.params['net_id']
+        org_id = meraki.get_org_id(meraki.params["org_name"])
+    net_id = meraki.params["net_id"]
     if net_id is None:
         nets = meraki.get_nets(org_id=org_id)
-        net_id = meraki.get_net_id(net_name=meraki.params['net_name'], data=nets)
+        net_id = meraki.get_net_id(net_name=meraki.params["net_name"], data=nets)
 
-    if meraki.params['state'] == 'query':
-        path = meraki.construct_path('query_update', net_id=net_id)
-        r = meraki.request(path, method='GET')
+    if meraki.params["state"] == "query":
+        path = meraki.construct_path("query_update", net_id=net_id)
+        r = meraki.request(path, method="GET")
         if meraki.status == 200:
-            meraki.result['data'] = r
-    elif meraki.params['state'] == 'present':
+            meraki.result["data"] = r
+    elif meraki.params["state"] == "present":
         # Construct payload
         payload = dict()
-        payload['servers'] = meraki.params['servers']
+        payload["servers"] = meraki.params["servers"]
 
         # Convert port numbers to string for idempotency checks
-        for server in payload['servers']:
-            if server['port']:
-                server['port'] = str(server['port'])
-        path = meraki.construct_path('query_update', net_id=net_id)
-        r = meraki.request(path, method='GET')
+        for server in payload["servers"]:
+            if server["port"]:
+                server["port"] = str(server["port"])
+        path = meraki.construct_path("query_update", net_id=net_id)
+        r = meraki.request(path, method="GET")
         if meraki.status == 200:
             original = r
+
+        # Roles must be sorted since out of order responses may break idempotency check
+        # Need to check to make sure servers are actually defined
+        if original is not None:
+            if len(original["servers"]) > 0:
+                sort_roles(original)
+        if payload is not None:
+            if len(payload["servers"]) > 0:
+                sort_roles(payload)
 
         if meraki.is_update_required(original, payload):
             if meraki.module.check_mode is True:
                 meraki.generate_diff(original, payload)
                 original.update(payload)
-                meraki.result['data'] = original
-                meraki.result['changed'] = True
+                meraki.result["data"] = original
+                meraki.result["changed"] = True
                 meraki.exit_json(**meraki.result)
-            path = meraki.construct_path('query_update', net_id=net_id)
-            r = meraki.request(path, method='PUT', payload=json.dumps(payload))
+            path = meraki.construct_path("query_update", net_id=net_id)
+            r = meraki.request(path, method="PUT", payload=json.dumps(payload))
             if meraki.status == 200:
                 meraki.generate_diff(original, r)
-                meraki.result['data'] = r
-                meraki.result['changed'] = True
+                meraki.result["data"] = r
+                meraki.result["changed"] = True
         else:
             if meraki.module.check_mode is True:
-                meraki.result['data'] = original
+                meraki.result["data"] = original
                 meraki.exit_json(**meraki.result)
-            meraki.result['data'] = original
+            meraki.result["data"] = original
 
     # in the event of a successful module execution, you will want to
     # simple AnsibleModule.exit_json(), passing the key/value results
     meraki.exit_json(**meraki.result)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tests/integration/targets/meraki_mr_rf_profile/tasks/main.yml
+++ b/tests/integration/targets/meraki_mr_rf_profile/tasks/main.yml
@@ -256,6 +256,58 @@
       that:
         - delete.data is defined
         - delete is changed
+- name: "Test RFProfile Bugfix from !281"
+  block:
+    - name: Create RF Profile
+      cisco.meraki.meraki_mr_rf_profile:
+        auth_key: '{{ auth_key }}'
+        org_name: '{{test_org_name}}'
+        net_name: IntTestNetworkWireless
+        name: "RF Profile - !281"
+        band_selection_type: ap
+        ap_band_settings:
+          mode: 'dual'
+        five_ghz_settings:
+          channel_width: 40
+        two_four_ghz_settings:
+          ax_enabled: 'no'
+        state: present
+      register: create_281
+    - assert:
+        that:
+          - create_281.data is defined
+          - create_281.data is changed
+    - name: Create RF Profile - Idempotent
+      cisco.meraki.meraki_mr_rf_profile:
+        auth_key: '{{ auth_key }}'
+        org_name: '{{test_org_name}}'
+        net_name: IntTestNetworkWireless
+        name: "RF Profile - !281"
+        band_selection_type: ap
+        ap_band_settings:
+          mode: 'dual'
+        five_ghz_settings:
+          channel_width: 40
+        two_four_ghz_settings:
+          ax_enabled: 'no'
+        state: present
+      register: idempotent_281
+    - assert:
+        that:
+          - idempotent_281.data is defined
+          - idempotent_281.data is not changed
+    - name: Clean Up RF Profile
+      cisco.meraki.meraki_mr_rf_profile:
+        auth_key: '{{ auth_key }}'
+        org_name: '{{test_org_name}}'
+        net_name: IntTestNetworkWireless
+        name: "RF Profile - !281"
+        state: absent
+      register: delete_281
+    - assert:
+        that:
+          - delete_281.data is defined
+          - delete_281.data is changed
 
 #############################################################################
 # Tear down starts here

--- a/tests/integration/targets/meraki_syslog/tasks/main.yml
+++ b/tests/integration/targets/meraki_syslog/tasks/main.yml
@@ -12,13 +12,15 @@
   - set_fact:
       syslog_test_net_name: 'syslog_{{test_net_name}}'
 
-  - name: Create network with type appliance and no timezone
+  - name: Create network with type appliance and switch
     meraki_network:
       auth_key: '{{ auth_key }}'
       state: present
       org_name: '{{test_org_name}}'
       net_name: '{{test_net_name}}'
-      type: appliance
+      type:
+        - appliance
+        - wireless
     delegate_to: localhost
     register: new_net
 
@@ -74,6 +76,48 @@
         - create_server_idempotency.changed == False
         - create_server_idempotency.data is defined
 
+  - name: Set syslog server with wireless Event log
+    meraki_syslog:
+      auth_key: '{{auth_key}}'
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      state: present
+      servers:
+        - host: 192.0.1.2
+          port: 514
+          roles:
+            - Appliance event log
+            - Flows
+            - wireless Event log
+    delegate_to: localhost
+    register: create_server
+
+  - assert:
+      that:
+        - create_server['data']['servers'][0]['host'] == "192.0.1.2"
+        - create_server is changed
+
+  - name: Set syslog server with wireless Event log with idempotency
+    meraki_syslog:
+      auth_key: '{{auth_key}}'
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+      state: present
+      servers:
+        - host: 192.0.1.2
+          port: 514
+          roles:
+            - Appliance event log
+            - Flows
+            - wireless event log
+    delegate_to: localhost
+    register: create_server_idempotency
+
+  - assert:
+      that:
+        - create_server_idempotency.changed == False
+        - create_server_idempotency.data is defined
+
   - name: Set multiple syslog servers
     meraki_syslog:
       auth_key: '{{auth_key}}'
@@ -121,7 +165,7 @@
 
   - assert:
       that:
-        - '"Invalid role found in servers" in invalid_role.msg'
+        - '"Invalid role found in" in invalid_role.msg'
 
   - name: Add role to existing syslog server  # Adding doesn't work, just creation
     meraki_syslog:

--- a/tests/integration/targets/meraki_syslog/tasks/main.yml
+++ b/tests/integration/targets/meraki_syslog/tasks/main.yml
@@ -45,12 +45,14 @@
           port: 514
           roles:
             - Appliance event log
+            - Flows
     delegate_to: localhost
     register: create_server
 
   - assert:
       that:
         - create_server['data']['servers'][0]['host'] == "192.0.1.2"
+        - create_server is changed
 
   - name: Set syslog server with idempotency
     meraki_syslog:
@@ -63,6 +65,7 @@
           port: 514
           roles:
             - Appliance event log
+            - Flows
     delegate_to: localhost
     register: create_server_idempotency
 


### PR DESCRIPTION
Fixes #288 

meraki_syslog would crash when multiple roles were provided and not in the same order. This PR adds a sort function to sort the roles so it would work properly. This also runs `black` on code.