### PR TITLE
rectified typo in function call fail_json

### DIFF
--- a/plugins/modules/meraki_mr_ssid.py
+++ b/plugins/modules/meraki_mr_ssid.py
@@ -595,7 +595,7 @@ def main():
             )
     if meraki.params["radius_accounting_enabled"] is True:
         if meraki.params["auth_mode"] not in ("open-with-radius", "8021x-radius"):
-            meraki.fails_json(
+            meraki.fail_json(
                 msg="radius_accounting_enabled is only allowed when auth_mode is open-with-radius or 8021x-radius"
             )
     if meraki.params["radius_accounting_servers"] is True:


### PR DESCRIPTION
function fail_json was mistyped as fails_json