### PR TITLE
Add `visible` argument to meraki_mr_ssid

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Cisco.Meraki Release Notes
 .. contents:: Topics
 
 
+v2.10.2
+=======
+
+Minor Changes
+-------------
+
+- meraki_ssid - Add support for `visible`.
+
 v2.10.1
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,14 +5,6 @@ Cisco.Meraki Release Notes
 .. contents:: Topics
 
 
-v2.10.2
-=======
-
-Minor Changes
--------------
-
-- meraki_ssid - Add support for `visible`.
-
 v2.10.1
 =======
 

--- a/changelogs/fragments/meraki_mr_ssid.yaml
+++ b/changelogs/fragments/meraki_mr_ssid.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - meraki_ssid - Add support for `visible`.

--- a/plugins/modules/meraki_mr_ssid.py
+++ b/plugins/modules/meraki_mr_ssid.py
@@ -163,6 +163,10 @@ options:
         - Set whether to use VLAN tagging.
         - Requires C(default_vlan_id) to be set.
         type: bool
+    visible:
+        description:
+        - Enable or disable whether APs should broadcast this SSID.
+        type: bool
     default_vlan_id:
         description:
         - Default VLAN ID.
@@ -245,6 +249,7 @@ EXAMPLES = r"""
     net_name: WiFi
     name: GuestSSID
     enabled: true
+    visible: true
   delegate_to: localhost
 
 - name: Set PSK with invalid encryption mode
@@ -409,6 +414,7 @@ def construct_payload(meraki):
         "radiusAccountingServers": "radius_accounting_servers",
         "ipAssignmentMode": "ip_assignment_mode",
         "useVlanTagging": "use_vlan_tagging",
+        "visible": "visible",
         "concentratorNetworkId": "concentrator_network_id",
         "vlanId": "vlan_id",
         "defaultVlanId": "default_vlan_id",
@@ -534,6 +540,7 @@ def main():
             ],
         ),
         use_vlan_tagging=dict(type="bool"),
+        visible=dict(type="bool"),
         concentrator_network_id=dict(type="str"),
         vlan_id=dict(type="int"),
         default_vlan_id=dict(type="int"),

--- a/tests/integration/targets/meraki_mr_ssid/meraki_ssid/tasks/main.yml
+++ b/tests/integration/targets/meraki_mr_ssid/meraki_ssid/tasks/main.yml
@@ -522,7 +522,7 @@
       net_name: TestNetSSID
       number: 1
       use_vlan_tagging: yes
-      visibile: true
+      visible: true
       ip_assignment_mode: Bridge mode
       ap_tags_vlan_ids:
         - tags: wifi

--- a/tests/integration/targets/meraki_mr_ssid/meraki_ssid/tasks/main.yml
+++ b/tests/integration/targets/meraki_mr_ssid/meraki_ssid/tasks/main.yml
@@ -207,6 +207,7 @@
       net_name: TestNetSSID
       number: 1
       use_vlan_tagging: yes
+      visible: yes
       ip_assignment_mode: Bridge mode
       default_vlan_id: 1
       ap_tags_vlan_ids:
@@ -229,6 +230,7 @@
       net_name: TestNetSSID
       number: 1
       use_vlan_tagging: yes
+      visible: yes
       ip_assignment_mode: Bridge mode
       default_vlan_id: 1
       ap_tags_vlan_ids:
@@ -520,6 +522,7 @@
       net_name: TestNetSSID
       number: 1
       use_vlan_tagging: yes
+      visibile: true
       ip_assignment_mode: Bridge mode
       ap_tags_vlan_ids:
         - tags: wifi


### PR DESCRIPTION
Add `visible` to `meraki_mr_ssid`

```
Boolean indicating whether APs should advertise or hide this SSID. APs will only broadcast this SSID if set to true