### PR TITLE
environmental Product Type is no more valid

### DIFF
--- a/plugins/modules/meraki_network.py
+++ b/plugins/modules/meraki_network.py
@@ -42,7 +42,7 @@ options:
         - Required when creating a network.
         - As of Ansible 2.8, C(combined) type is no longer accepted.
         - As of Ansible 2.8, changes to this parameter are no longer idempotent.
-        choices: [ appliance, switch, wireless, sensor, environmental, camera, cellularGateway ]
+        choices: [ appliance, switch, wireless, sensor, systemsManager, camera, cellularGateway ]
         aliases: [ net_type ]
         type: list
         elements: str
@@ -237,7 +237,7 @@ def main():
                 "switch",
                 "appliance",
                 "sensor",
-                "environmental",
+                "systemsManager",
                 "camera",
                 "cellularGateway",
             ],


### PR DESCRIPTION
The Meraki API module for network creation has changed and "environmental" is no more a valid option, on running the play book with environmental product type get an error:
 Each element in 'productTypes' must be one of: 'wireless', 'appliance', 'switch', 'systemsManager', 'camera', 'cellularGateway' or 'sensor'", "response": "OK (unknown bytes)", "status": 400}
Therefore, changing the documentation on the module and the choice of the module to the new product type which is systemsManager https://developer.cisco.com/meraki/api-latest/#!create-organization-network
Note: That in the above link environmental is still shown as an attribute but doesn't works when creating the network with curl/PostmanAPI