### PR TITLE
Fix test meraki mr radio

### DIFF
--- a/changelogs/fragments/fix-meraki-mr-radio-tests.yml
+++ b/changelogs/fragments/fix-meraki-mr-radio-tests.yml
@@ -1,0 +1,2 @@
+trivial:
+  - Changed the tests for meraki_mr_radio

--- a/tests/integration/targets/meraki_mr_radio/tasks/main.yml
+++ b/tests/integration/targets/meraki_mr_radio/tasks/main.yml
@@ -10,10 +10,11 @@
       auth_key: "{{ auth_key }}"
       state: present
       org_name: "{{ test_org_name }}"
-      net_id: '{{ test_net_id }}'
+      net_name: IntTestNetwork
       type: wireless
       timezone: America/Chicago
     delegate_to: localhost
+    register: created_network
 
   - name: Add access points to network
     cisco.meraki.meraki_device:

--- a/tests/integration/targets/meraki_mr_radio/tasks/main.yml
+++ b/tests/integration/targets/meraki_mr_radio/tasks/main.yml
@@ -107,7 +107,7 @@
       state: present
       serial: "{{ serial_wireless }}"
       five_ghz_settings:
-        channel: 40
+        channel: 100
         channel_width: 20
         target_power: 10
       two_four_ghz_settings:
@@ -131,7 +131,7 @@
       state: present
       serial: "{{ serial_wireless }}"
       five_ghz_settings:
-        channel: 40
+        channel: 100
         channel_width: 20
         target_power: 10
       two_four_ghz_settings:

--- a/tests/integration/targets/meraki_mr_radio/tasks/main.yml
+++ b/tests/integration/targets/meraki_mr_radio/tasks/main.yml
@@ -10,7 +10,7 @@
       auth_key: "{{ auth_key }}"
       state: present
       org_name: "{{ test_org_name }}"
-      net_name: IntTestNetworkWireless
+      net_id: '{{ test_net_id }}'
       type: wireless
       timezone: America/Chicago
     delegate_to: localhost
@@ -20,7 +20,7 @@
       auth_key: "{{ auth_key }}"
       state: present
       org_name: "{{ test_org_name }}"
-      net_name: IntTestNetworkWireless
+      net_id: '{{ test_net_id }}'
       serial: "{{ serial_wireless }}"
     delegate_to: localhost
 
@@ -28,7 +28,7 @@
     cisco.meraki.meraki_mr_rf_profile:
       auth_key: "{{ auth_key }}"
       org_name: "{{ test_org_name }}"
-      net_name: IntTestNetworkWireless
+      net_id: '{{ test_net_id }}'
       state: present
       name: Test Profile
       band_selection_type: ap
@@ -65,7 +65,7 @@
     cisco.meraki.meraki_mr_radio:
       auth_key: "{{ auth_key }}"
       org_name: "{{ test_org_name }}"
-      net_name: IntTestNetworkWireless
+      net_id: '{{ test_net_id }}'
       state: present
       serial: "{{ serial_wireless }}"
       five_ghz_settings:
@@ -103,7 +103,7 @@
     cisco.meraki.meraki_mr_radio:
       auth_key: "{{ auth_key }}"
       org_name: "{{ test_org_name }}"
-      net_name: IntTestNetworkWireless
+      net_id: '{{ test_net_id }}'
       state: present
       serial: "{{ serial_wireless }}"
       five_ghz_settings:
@@ -127,7 +127,7 @@
     cisco.meraki.meraki_mr_radio:
       auth_key: "{{ auth_key }}"
       org_name: "{{ test_org_name }}"
-      net_name: IntTestNetworkWireless
+      net_id: '{{ test_net_id }}'
       state: present
       serial: "{{ serial_wireless }}"
       five_ghz_settings:
@@ -157,5 +157,5 @@
         auth_key: '{{ auth_key }}'
         state: absent
         org_name: '{{ test_org_name }}'
-        net_name: IntTestNetworkWireless
+        net_id: '{{ test_net_id }}'
       delegate_to: localhost

--- a/tests/integration/targets/meraki_mr_radio/tasks/main.yml
+++ b/tests/integration/targets/meraki_mr_radio/tasks/main.yml
@@ -16,6 +16,10 @@
     delegate_to: localhost
     register: created_network
 
+  - name: Setting the net_id
+    ansible.builtin.set_fact:
+      created_net_id: '{{ created_network.data.id }}'
+
   - name: Add access points to network
     cisco.meraki.meraki_device:
       auth_key: "{{ auth_key }}"

--- a/tests/integration/targets/meraki_mr_radio/tasks/main.yml
+++ b/tests/integration/targets/meraki_mr_radio/tasks/main.yml
@@ -10,7 +10,7 @@
       auth_key: "{{ auth_key }}"
       state: present
       org_name: "{{ test_org_name }}"
-      net_name: IntTestNetwork
+      net_name: IntTestNetworkWireless
       type: wireless
       timezone: America/Chicago
     delegate_to: localhost
@@ -25,7 +25,7 @@
       auth_key: "{{ auth_key }}"
       state: present
       org_name: "{{ test_org_name }}"
-      net_id: '{{ test_net_id }}'
+      net_id: '{{ created_net_id }}'
       serial: "{{ serial_wireless }}"
     delegate_to: localhost
 
@@ -33,7 +33,7 @@
     cisco.meraki.meraki_mr_rf_profile:
       auth_key: "{{ auth_key }}"
       org_name: "{{ test_org_name }}"
-      net_id: '{{ test_net_id }}'
+      net_id: '{{ created_net_id }}'
       state: present
       name: Test Profile
       band_selection_type: ap
@@ -70,7 +70,7 @@
     cisco.meraki.meraki_mr_radio:
       auth_key: "{{ auth_key }}"
       org_name: "{{ test_org_name }}"
-      net_id: '{{ test_net_id }}'
+      net_id: '{{ created_net_id }}'
       state: present
       serial: "{{ serial_wireless }}"
       five_ghz_settings:
@@ -108,7 +108,7 @@
     cisco.meraki.meraki_mr_radio:
       auth_key: "{{ auth_key }}"
       org_name: "{{ test_org_name }}"
-      net_id: '{{ test_net_id }}'
+      net_id: '{{ created_net_id }}'
       state: present
       serial: "{{ serial_wireless }}"
       five_ghz_settings:
@@ -132,7 +132,7 @@
     cisco.meraki.meraki_mr_radio:
       auth_key: "{{ auth_key }}"
       org_name: "{{ test_org_name }}"
-      net_id: '{{ test_net_id }}'
+      net_id: '{{ created_net_id }}'
       state: present
       serial: "{{ serial_wireless }}"
       five_ghz_settings:
@@ -162,5 +162,5 @@
         auth_key: '{{ auth_key }}'
         state: absent
         org_name: '{{ test_org_name }}'
-        net_id: '{{ test_net_id }}'
+        net_id: '{{ created_net_id }}'
       delegate_to: localhost


### PR DESCRIPTION
Resolving: #380 
I got the error:
```
Running meraki_mr_radio integration test role                                                                                                                 [WARNING]: running playbook inside collection cisco.meraki

PLAY [meraki] ******************************************************************
                                                                                                                                                              TASK [meraki_mr_radio : Create network with type wireless] *********************
[WARNING]: Platform darwin on host localhost is using the discovered Python
interpreter at /opt/homebrew/bin/python3.11, but future installation of another
Python interpreter could change the meaning of that path. See
https://docs.ansible.com/ansible-
core/2.14/reference_appendices/interpreter_discovery.html for more information.
fatal: [localhost]: FAILED! => {"changed": false, "msg": 403, "response": "OK (unknown bytes)", "status": 403, "url": "https://api.meraki.com/api/v1/organizat
ions/549236/networks"}

TASK [meraki_mr_radio : Delete network] ****************************************
ok: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0

NOTICE: To resume at this test target, use the option: --start-at meraki_mr_radio
FATAL: Command "ansible-playbook meraki_mr_radio-gq3kboby.yml -i inventory.networking" returned exit status 2.
```

After the change (e9e5fee2929e6369ae963dc1f7409cd6cb9720d8) I got another error:
```
TASK [meraki_mr_radio : Configure AP radios] ***********************************
fatal: [localhost]: FAILED! => {"changed": false, "data": {"fiveGhzSettings": {"channel": null, "channelWidth": null, "targetPower": null}, "rfProfileId": null, "serial": "Q2EK-S3AA-BXFW", "twoFourGhzSettings": {"channel": null, "targetPower": null}}, "msg": "HTTP error 400 - https://api.meraki.com/api/v1/devices/Q2EK-S3AA-BXFW/wireless/radio/settings - Invalid channel for fiveGhzSettings: channel must be in 100, 104, 108, 112, 116, 132, 136, 140", "response": "OK (unknown bytes)", "status": 400}
```

I resolved above error in (a75997f32169a1e41996fba13052142fbb202ffc).

I think another issue has been occurred due to permission to create/delete a network in Dev SandBox. Should I remove the always to remove it @kbreit?

```diff
diff --git a/tests/integration/targets/meraki_mr_radio/tasks/main.yml b/tests/integration/targets/meraki_mr_radio/tasks/main.yml
index 4de7955..5efa844 100644
--- a/tests/integration/targets/meraki_mr_radio/tasks/main.yml
+++ b/tests/integration/targets/meraki_mr_radio/tasks/main.yml
@@ -146,16 +146,3 @@
       that:
         - update_idempotent.data is defined
         - update_idempotent is not changed
-
-#############################################################################
-# Tear down starts here
-#############################################################################
-
-  always:
-    - name: Delete network
-      cisco.meraki.meraki_network:
-        auth_key: '{{ auth_key }}'
-        state: absent
-        org_name: '{{ test_org_name }}'
-        net_id: '{{ test_net_id }}'
-      delegate_to: localhost
```