### PR TITLE
Add additional catching of exception in meraki_webhook

### DIFF
--- a/changelogs/fragments/bugfixes-meraki_webhook.yml
+++ b/changelogs/fragments/bugfixes-meraki_webhook.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Add additional except of IndexError error during sanitizing of empty data in meraki_webhook

--- a/plugins/modules/meraki_webhook.py
+++ b/plugins/modules/meraki_webhook.py
@@ -189,7 +189,7 @@ def sanitize_no_log_values(meraki):
         pass
     try:
         meraki.result['data'][0]['shared_secret'] = 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'
-    except KeyError:
+    except (KeyError, IndexError):
         pass
     try:
         meraki.result['data']['shared_secret'] = 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'


### PR DESCRIPTION
When running 
```- name: Query all webhooks
  meraki_webhook:
    auth_key: abc123
    state: query
    org_name: YourOrg
    net_name: YourNet
  delegate_to: localhost
```

On a network with NO configured webhooks, 

```An exception occurred during task execution. To see the full traceback, use -vvv. The error was: IndexError: list index out of range
fatal: [localhost]: FAILED! => changed=false
  module_stderr: |-
    Traceback (most recent call last):
      File "/Users/joshuacoronado/.ansible/tmp/ansible-tmp-1668543657.4904928-60576-213755332734982/AnsiballZ_meraki_webhook.py", line 107, in <module>
        _ansiballz_main()
      File "/Users/joshuacoronado/.ansible/tmp/ansible-tmp-1668543657.4904928-60576-213755332734982/AnsiballZ_meraki_webhook.py", line 99, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/Users/joshuacoronado/.ansible/tmp/ansible-tmp-1668543657.4904928-60576-213755332734982/AnsiballZ_meraki_webhook.py", line 47, in invoke_module
        runpy.run_module(mod_name='ansible_collections.cisco.meraki.plugins.modules.meraki_webhook', init_globals=dict(_module_fqn='ansible_collections.cisco.meraki.plugins.modules.meraki_webhook', _modlib_path=modlib_path),
      File "/Users/joshuacoronado/.pyenv/versions/3.10.6/lib/python3.10/runpy.py", line 224, in run_module
        return _run_module_code(code, init_globals, run_name, mod_spec)
      File "/Users/joshuacoronado/.pyenv/versions/3.10.6/lib/python3.10/runpy.py", line 96, in _run_module_code
        _run_code(code, mod_globals, init_globals,
      File "/Users/joshuacoronado/.pyenv/versions/3.10.6/lib/python3.10/runpy.py", line 86, in _run_code
        exec(code, run_globals)
      File "/var/folders/8b/p2kvgjvn0bj425c3bbyzkxv40000gn/T/ansible_cisco.meraki.meraki_webhook_payload_vj3yclai/ansible_cisco.meraki.meraki_webhook_payload.zip/ansible_collections/cisco/meraki/plugins/modules/meraki_webhook.py", line 347, in <module>
      File "/var/folders/8b/p2kvgjvn0bj425c3bbyzkxv40000gn/T/ansible_cisco.meraki.meraki_webhook_payload_vj3yclai/ansible_cisco.meraki.meraki_webhook_payload.zip/ansible_collections/cisco/meraki/plugins/modules/meraki_webhook.py", line 282, in main
      File "/var/folders/8b/p2kvgjvn0bj425c3bbyzkxv40000gn/T/ansible_cisco.meraki.meraki_webhook_payload_vj3yclai/ansible_cisco.meraki.meraki_webhook_payload.zip/ansible_collections/cisco/meraki/plugins/modules/meraki_webhook.py", line 191, in sanitize_no_log_values
    IndexError: list index out of range
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr
```

To fix this, I updated `sanitize_no_log_values` in `meraki_webhook.py` to also catch the `IndexError` exception. Another option would to add an if statement like 
```
if meraki.result['data']:
  dostuff
```
but felt like adding the exception was more in line with the existing code