### PR TITLE
Add module for managing webhook payload templates

### DIFF
--- a/changelogs/fragments/meraki_webhook_payload_template.yml
+++ b/changelogs/fragments/meraki_webhook_payload_template.yml
@@ -1,0 +1,2 @@
+major_changes:
+  - meraki_webhook_payload_template - New module

--- a/plugins/modules/meraki_webhook_payload_template.py
+++ b/plugins/modules/meraki_webhook_payload_template.py
@@ -8,8 +8,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import sys
-
 ANSIBLE_METADATA = {
     "metadata_version": "1.1",
     "status": ["preview"],
@@ -50,6 +48,7 @@ options:
         - List of the liquid templates used with the webhook headers.
         type: list
         elements: dict
+        default: []
         suboptions:
             name:
                 description:

--- a/plugins/modules/meraki_webhook_payload_template.py
+++ b/plugins/modules/meraki_webhook_payload_template.py
@@ -1,0 +1,300 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2012, Joshua Coronado (@joshuajcoronado) <joshua@coronado.io>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import sys
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = r"""
+---
+module: meraki_webhook_payload_template
+short_description: Manage webhook payload templates for a network in the Meraki cloud
+description:
+- Allows for querying, deleting, creating, and updating of webhook payload templates.
+options:
+    state:
+        description:
+        - Specifies whether payload template should be queried, created, modified, or deleted.
+        choices: ['absent', 'query', 'present']
+        default: query
+        type: str
+    name:
+        description:
+        - Name of the template.
+        type: str
+    net_name:
+        description:
+        - Name of network containing access points.
+        type: str
+    net_id:
+        description:
+        - ID of network containing access points.
+        type: str
+    body:
+        description:
+        - The liquid template used for the body of the webhook message.
+        type: str
+    headers:
+        description:
+        - List of the liquid templates used with the webhook headers.
+        type: list
+        elements: dict
+        suboptions:
+            name:
+                description:
+                - The name of the header template.
+                type: str
+            template:
+                description:
+                - The liquid template for the headers
+                type: str
+author:
+- Joshua Coronado (@joshuajcoronado)
+extends_documentation_fragment: cisco.meraki.meraki
+"""
+
+EXAMPLES = r"""
+- name: Query all configuration templates
+  meraki_webhook_payload_template:
+    auth_key: abc12345
+    org_name: YourOrg
+    state: query
+  delegate_to: localhost
+
+- name: Query specific configuration templates
+  meraki_webhook_payload_template:
+    auth_key: abc12345
+    org_name: YourOrg
+    state: query
+    name: Twitter
+  delegate_to: localhost
+
+- name: Delete a configuration template
+  meraki_config_template:
+    auth_key: abc123
+    state: absent
+    org_name: YourOrg
+    name: Twitter
+  delegate_to: localhost
+"""
+
+RETURN = r"""
+data:
+    description: Information about queried object.
+    returned: success
+    type: complex
+    contains:
+        name:
+          description: Name of webhook template.
+          returned: success
+          type: str
+          sample: YourTemplate
+"""
+
+from ansible.module_utils.basic import AnsibleModule, json
+from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import (
+    MerakiModule,
+    meraki_argument_spec,
+)
+
+
+def get_webhook_payload_templates(meraki, net_id):
+    path = meraki.construct_path("get_all", net_id=net_id)
+    response = meraki.request(path, "GET")
+    if meraki.status != 200:
+        meraki.fail_json(msg="Unable to get webhook payload templates")
+    return response
+
+
+def delete_template(meraki, net_id, template_id):
+    path = meraki.construct_path(
+        "update", net_id=net_id, custom={"template_id": template_id}
+    )
+    response = meraki.request(path, method="DELETE")
+    if meraki.status != 204:
+        meraki.fail_json(msg="Unable to remove webhook payload templates")
+    return response
+
+
+def create_template(meraki, net_id, template):
+    path = meraki.construct_path("get_all", net_id=net_id)
+    response = meraki.request(path, "POST", payload=json.dumps(template))
+    if meraki.status != 201:
+        meraki.fail_json(msg="Unable to create webhook payload template")
+    return response
+
+
+def update_template(meraki, net_id, template, payload):
+
+    path = meraki.construct_path(
+        "update",
+        net_id=net_id,
+        custom={"template_id": template["payloadTemplateId"]},
+    )
+    changed = False
+    if template["body"] != payload["body"]:
+        changed = True
+
+    if meraki.is_update_required(template["headers"], payload["headers"]):
+        changed = True
+
+    if changed:
+        response = meraki.request(
+            path, method="PUT", payload=json.dumps(payload)
+        )
+        if meraki.status != 200:
+            meraki.fail_json(msg="Unable to update webhook payload template")
+        return response, changed
+
+    return template, changed
+
+
+def main():
+
+    # define the available arguments/parameters that a user can pass to
+    # the module
+    argument_spec = meraki_argument_spec()
+    argument_spec.update(
+        state=dict(
+            type="str", choices=["absent", "query", "present"], default="query"
+        ),
+        name=dict(type="str", default=None),
+        net_name=dict(type="str"),
+        net_id=dict(type="str"),
+        body=dict(type="str", default=None),
+        headers=dict(
+            type="list",
+            default=[],
+            elements="dict",
+            options=dict(
+                name=dict(type="str"),
+                template=dict(type="str"),
+            ),
+        ),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+    meraki = MerakiModule(module, function="webhook_payload_template")
+    meraki.params["follow_redirects"] = "all"
+
+    query_all_urls = {
+        "webhook_payload_template": "/networks/{net_id}/webhooks/payloadTemplates"
+    }
+    update_urls = {
+        "webhook_payload_template": "/networks/{net_id}/webhooks/payloadTemplates/{template_id}"
+    }
+
+    meraki.url_catalog["get_all"].update(query_all_urls)
+    meraki.url_catalog["update"] = update_urls
+
+    org_id = meraki.params["org_id"]
+    if meraki.params["org_name"]:
+        org_id = meraki.get_org_id(meraki.params["org_name"])
+    net_id = meraki.params["net_id"]
+
+    if net_id is None:
+        if meraki.params["net_name"] is not None:
+            nets = meraki.get_nets(org_id=org_id)
+            net_id = meraki.get_net_id(
+                net_name=meraki.params["net_name"], data=nets
+            )
+
+    templates = {
+        template["name"]: template
+        for template in get_webhook_payload_templates(meraki, net_id)
+    }
+
+    if meraki.params["state"] == "query":
+        meraki.result["changed"] = False
+
+        if meraki.params["name"]:
+            if meraki.params["name"] in templates:
+                meraki.result["data"] = templates[meraki.params["name"]]
+            else:
+                meraki.fail_json(
+                    msg=f"Unable to get webhook payload template named: {meraki.params['name']}"
+                )
+        else:
+            meraki.result["data"] = templates
+
+    elif meraki.params["state"] == "present":
+        if meraki.params["name"] is None:
+            meraki.fail_json(msg="name is a required parameter")
+
+        if meraki.params["body"] is None:
+            meraki.fail_json(
+                msg="body is a required parameter when state is present"
+            )
+        headers = []
+
+        for header in meraki.params["headers"]:
+            for key in ["name", "template"]:
+                if key not in header:
+                    meraki.fail_json(
+                        msg=f"{key} is a required parameter for a header"
+                    )
+                if not header[key]:
+                    meraki.fail_json(msg=f"{key} in header must be a string")
+            headers.append(
+                dict(name=header["name"], template=header["template"])
+            )
+
+        payload = {
+            "name": meraki.params["name"],
+            "body": meraki.params["body"],
+            "headers": meraki.params["headers"],
+        }
+
+        if meraki.check_mode:
+            meraki.result["data"] = payload
+            meraki.result["changed"] = False
+        else:
+            if meraki.params["name"] in templates:
+                (
+                    meraki.result["data"],
+                    meraki.result["changed"],
+                ) = update_template(
+                    meraki, net_id, templates[meraki.params["name"]], payload
+                )
+            else:
+                meraki.result["data"] = create_template(
+                    meraki, net_id, payload
+                )
+                meraki.result["changed"] = True
+    elif meraki.params["state"] == "absent":
+        if meraki.params.get("name") in templates:
+            meraki.result["changed"] = True
+
+            if meraki.check_mode:
+                meraki.result["data"] = {}
+            else:
+                meraki.result["data"] = delete_template(
+                    meraki,
+                    net_id,
+                    templates[meraki.params["name"]]["payloadTemplateId"],
+                )
+        else:
+            meraki.result["changed"] = False
+            meraki.result["data"] = {}
+
+    # in the event of a successful module execution, you will want to
+    # simple AnsibleModule.exit_json(), passing the key/value results
+    meraki.exit_json(**meraki.result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/meraki_webhook_payload_template.py
+++ b/plugins/modules/meraki_webhook_payload_template.py
@@ -317,7 +317,7 @@ def main():
                 )
                 meraki.result["changed"] = True
     elif meraki.params["state"] == "absent":
-        if meraki.params.get("name") in templates:
+        if meraki.params["name"]in templates:
             meraki.result["changed"] = True
 
             if meraki.check_mode:

--- a/plugins/modules/meraki_webhook_payload_template.py
+++ b/plugins/modules/meraki_webhook_payload_template.py
@@ -261,7 +261,9 @@ def main():
                 meraki.result["data"] = templates[meraki.params["name"]]
             else:
                 meraki.fail_json(
-                    msg=f"Unable to get webhook payload template named: {meraki.params['name']}"
+                    msg="Unable to get webhook payload template named: {0}".format(
+                        meraki.params["name"]
+                    )
                 )
         else:
             meraki.result["data"] = templates
@@ -280,10 +282,14 @@ def main():
             for key in ["name", "template"]:
                 if key not in header:
                     meraki.fail_json(
-                        msg=f"{key} is a required parameter for a header"
+                        msg="{0} is a required parameter for a header".format(
+                            key
+                        )
                     )
                 if not header[key]:
-                    meraki.fail_json(msg=f"{key} in header must be a string")
+                    meraki.fail_json(
+                        msg="{0} in header must be a string".format(key)
+                    )
             headers.append(
                 dict(name=header["name"], template=header["template"])
             )

--- a/plugins/modules/meraki_webhook_payload_template.py
+++ b/plugins/modules/meraki_webhook_payload_template.py
@@ -317,7 +317,7 @@ def main():
                 )
                 meraki.result["changed"] = True
     elif meraki.params["state"] == "absent":
-        if meraki.params["name"]in templates:
+        if meraki.params["name"] in templates:
             meraki.result["changed"] = True
 
             if meraki.check_mode:

--- a/plugins/modules/meraki_webhook_payload_template.py
+++ b/plugins/modules/meraki_webhook_payload_template.py
@@ -80,12 +80,24 @@ EXAMPLES = r"""
     name: Twitter
   delegate_to: localhost
 
+- name: Create payload template
+  meraki_webhook_payload_template:
+    auth_key: abc12345
+    org_name: YourOrg
+    state: query
+    name: TestTemplate
+    body: Testbody
+    headers:
+        - name: testheader
+          template: testheadertemplate
+  delegate_to: localhost
+
 - name: Delete a configuration template
   meraki_config_template:
     auth_key: abc123
     state: absent
     org_name: YourOrg
-    name: Twitter
+    name: TestTemplate
   delegate_to: localhost
 """
 
@@ -96,10 +108,34 @@ data:
     type: complex
     contains:
         name:
-          description: Name of webhook template.
-          returned: success
-          type: str
-          sample: YourTemplate
+            description:
+                - The name of the template
+            returned: success
+            type: str
+            sample: testTemplate
+        body:
+            description:
+                - The liquid template used for the body of the webhook message.
+            returned: success
+            type: str
+            sample: {"event_type":"{{alertTypeId}}","client_payload":{"text":"{{alertData}}"}}
+        headers:
+            description: List of the liquid templates used with the webhook headers.
+            returned: success
+            type: list
+            contains:
+                name:
+                    description:
+                        - The name of the template
+                    returned: success
+                    type: str
+                    sample: testTemplate
+                template:
+                    description:
+                        - The liquid template for the header
+                    returned: success
+                    type: str
+                    sample: "Bearer {{sharedSecret}}"
 """
 
 from ansible.module_utils.basic import AnsibleModule, json

--- a/tests/integration/targets/meraki_webhook_payload_template/aliases
+++ b/tests/integration/targets/meraki_webhook_payload_template/aliases
@@ -1,0 +1,2 @@
+unsupported
+

--- a/tests/integration/targets/meraki_webhook_payload_template/tasks/main.yml
+++ b/tests/integration/targets/meraki_webhook_payload_template/tasks/main.yml
@@ -1,4 +1,3 @@
-
 # Test code for the Meraki modules
 
 # Copyright: (c) 2022, Joshua Coronado (@joshuajcoronado) <joshua@coronado.io>

--- a/tests/integration/targets/meraki_webhook_payload_template/tasks/main.yml
+++ b/tests/integration/targets/meraki_webhook_payload_template/tasks/main.yml
@@ -1,0 +1,8 @@
+
+# Test code for the Meraki modules
+
+# Copyright: (c) 2022, Joshua Coronado (@joshuajcoronado) <joshua@coronado.io>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: Run test cases
+  include: tests.yml ansible_connection=local

--- a/tests/integration/targets/meraki_webhook_payload_template/tasks/tests.yml
+++ b/tests/integration/targets/meraki_webhook_payload_template/tasks/tests.yml
@@ -32,7 +32,7 @@
         - query.data | length > 1
 
   - name: Create webhook payload template
-    cisco.meraki.meraki_mr_l7_firewall:
+    cisco.meraki.meraki_webhook_payload_template:
       auth_key: '{{ auth_key }}'
       org_name: '{{ test_org_name }}'
       net_id: '{{ net }}'
@@ -71,7 +71,7 @@
         - query.data.body == "a fake body"
 
   - name: Update webhook payload template
-    cisco.meraki.meraki_mr_l7_firewall:
+    cisco.meraki.meraki_webhook_payload_template:
       auth_key: '{{ auth_key }}'
       org_name: '{{ test_org_name }}'
       net_id: '{{ net }}'
@@ -95,7 +95,7 @@
         - update_basic_template.data.headers | length == 1
 
   - name: Test idempotency by updating webhook payload template
-    cisco.meraki.meraki_mr_l7_firewall:
+    cisco.meraki.meraki_webhook_payload_template:
       auth_key: '{{ auth_key }}'
       org_name: '{{ test_org_name }}'
       net_id: '{{ net }}'

--- a/tests/integration/targets/meraki_webhook_payload_template/tasks/tests.yml
+++ b/tests/integration/targets/meraki_webhook_payload_template/tasks/tests.yml
@@ -31,6 +31,25 @@
         - query.data is defined
         - query.data | length > 1
 
+  - name: Create payload template with check mode
+    cisco.meraki.meraki_webhook_payload_template:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{ test_org_name }}'
+      net_id: '{{ net }}'
+      state: present
+      name: TestTemplate
+      body: "a fake body"
+    check_mode: yes
+    register: create_one_check
+
+  - ansible.builtin.debug:
+      var: create_one_check
+
+  - ansible.builtin.assert:
+      that:
+        - create_one_check is changed
+        - create_one_check.data is defined
+
   - name: Create webhook payload template
     cisco.meraki.meraki_webhook_payload_template:
       auth_key: '{{ auth_key }}'
@@ -115,6 +134,23 @@
     ansible.builtin.assert:
       that:
         - not idempotent_update_basic_template.changed
+
+  - name: Delete webhook payload template in check mode
+    cisco.meraki.meraki_webhook_payload_template:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{ test_org_name }}'
+      net_id: '{{ net }}'
+      state: absent
+      name: TestTemplate
+    check_mode: yes
+    register: delete_check
+
+  - ansible.builtin.debug:
+      var: delete_check
+
+  - ansible.builtin.assert:
+      that:
+        - delete_check is changed
 
   - name: Delete basic template
     cisco.meraki.meraki_webhook_payload_template:

--- a/tests/integration/targets/meraki_webhook_payload_template/tasks/tests.yml
+++ b/tests/integration/targets/meraki_webhook_payload_template/tasks/tests.yml
@@ -1,0 +1,235 @@
+# Test code for the Meraki modules
+
+# Copyright: (c) 2022, Joshua Coronado (@joshuajcoronado) <joshua@coronado.io>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+---
+- name: Block of tasks
+  block:
+  - name: Create network
+    cisco.meraki.meraki_network:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{ test_org_name }}'
+      net_name: TestNet
+      state: present
+      type: wireless
+    register: new_net
+
+  - name: Set fact new_net
+    ansible.builtin.set_fact:
+      net: '{{ new_net.data.id }}'
+
+  - name: Query all webhook payload templates
+    cisco.meraki.meraki_webhook_payload_template:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{ test_org_name }}'
+      net_id: '{{ net }}'
+      state: query
+    register: query
+
+  - name: Assert query.data is defined
+    ansible.builtin.assert:
+      that:
+        - query.data is defined
+        - query.data | length > 1
+
+  - name: Create webhook payload template
+    cisco.meraki.meraki_mr_l7_firewall:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{ test_org_name }}'
+      net_id: '{{ net }}'
+      state: present
+      name: TestTemplate
+      body: "a fake body"
+    register: basic_template
+
+  - name: Debug basic_template
+    ansible.builtin.debug:
+      var: basic_template
+
+  - name: Assert things were changed
+    ansible.builtin.assert:
+      that:
+        - basic_template.changed
+
+  - name: Query basic template
+    cisco.meraki.meraki_webhook_payload_template:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{ test_org_name }}'
+      net_id: '{{ net }}'
+      state: query
+      name: TestTemplate
+    register: query
+
+  - name: Debug query
+    ansible.builtin.debug:
+      var: query
+
+  - name: Assert basic template was created
+    ansible.builtin.assert:
+      that:
+        - query.data is defined
+        - not query.changed
+        - query.data.body == "a fake body"
+
+  - name: Update webhook payload template
+    cisco.meraki.meraki_mr_l7_firewall:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{ test_org_name }}'
+      net_id: '{{ net }}'
+      state: present
+      name: TestTemplate
+      body: "a fake body"
+      headers:
+        - name: header1
+          template: "fake header1"
+    register: update_basic_template
+
+  - name: Debug update_basic_template
+    ansible.builtin.debug:
+      var: update_basic_template
+
+  - name: Assert update happened
+    ansible.builtin.assert:
+      that:
+        - update_basic_template.data is defined
+        - update_basic_template.changed
+        - update_basic_template.data.headers | length == 1
+
+  - name: Test idempotency by updating webhook payload template
+    cisco.meraki.meraki_mr_l7_firewall:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{ test_org_name }}'
+      net_id: '{{ net }}'
+      state: present
+      name: TestTemplate
+      body: "a fake body"
+      headers:
+        - name: header1
+          template: "fake header1"
+    register: idempotent_update_basic_template
+
+  - name: Debug update_basic_template
+    ansible.builtin.debug:
+      var: idempotent_update_basic_template
+
+  - name: Assert nothing changed
+    ansible.builtin.assert:
+      that:
+        - not idempotent_update_basic_template.changed
+
+  - name: Delete basic template
+    cisco.meraki.meraki_webhook_payload_template:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{ test_org_name }}'
+      net_id: '{{ net }}'
+      state: absent
+      name: TestTemplate
+    register: delete_template
+
+  - name: Debug delete_template
+    ansible.builtin.debug:
+      var: delete_template
+
+  - name: Assert the thing was deleted and changed
+    ansible.builtin.assert:
+      that:
+        - delete_template.changed
+
+  - name: Delete basic template idempotent
+    cisco.meraki.meraki_webhook_payload_template:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{ test_org_name }}'
+      net_id: '{{ net }}'
+      state: absent
+      name: TestTemplate
+    register: idempotent_delete_template
+
+  - name: Debug delete_template
+    ansible.builtin.debug:
+      var: idempotent_delete_template
+
+  - name: Assert nothing was changed
+    ansible.builtin.assert:
+      that:
+        - not idempotent_delete_template.changed
+
+  - name: Query deleted basic template
+    cisco.meraki.meraki_webhook_payload_template:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{ test_org_name }}'
+      net_id: '{{ net }}'
+      state: query
+      name: TestTemplate
+    register: deleted_template
+    ignore_errors: true
+
+  - name: Debug deleted_template
+    ansible.builtin.debug:
+      var: deleted_template
+
+  - name: Assert we hit an error
+    ansible.builtin.assert:
+      that:
+        - 'deleted_template.msg == "Unable to get webhook payload template named: TestTemplate"'
+
+  #########################################
+  ##  Tests for argument completeness    ##
+  #########################################
+  - name: Test body check
+    cisco.meraki.meraki_webhook_payload_template:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{ test_org_name }}'
+      net_id: '{{ net }}'
+      state: present
+      name: TestTemplate
+    register: error_no_body
+    ignore_errors: true
+
+  - name: Assert body is required when creating/updating a template
+    ansible.builtin.assert:
+      that:
+        - 'error_no_body.msg == "body is a required parameter when state is present"'
+
+  - name: Test name check
+    cisco.meraki.meraki_webhook_payload_template:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{ test_org_name }}'
+      net_id: '{{ net }}'
+      state: present
+    register: error_no_name
+    ignore_errors: true
+
+  - name: Assert name is required when creating/updating/deleting a template
+    ansible.builtin.assert:
+      that:
+        - 'error_no_body.msg == "name is a required parameter"'
+
+  - name: Test headers args
+    cisco.meraki.meraki_webhook_payload_template:
+      auth_key: '{{ auth_key }}'
+      org_name: '{{ test_org_name }}'
+      net_id: '{{ net }}'
+      state: present
+      name: Test
+      body: "fake body"
+      headers:
+        - name: test
+    register: header_args
+    ignore_errors: true
+
+  - name: Assert headers args are there
+    ansible.builtin.assert:
+      that:
+        - 'error_no_body.msg == "template in header must be a string"'
+
+############################################################################
+# Tear down starts here
+############################################################################
+  always:
+
+    - name: Delete wireless network
+      cisco.meraki.meraki_network:
+        auth_key: '{{ auth_key }}'
+        state: absent
+        org_name: '{{ test_org_name }}'
+        net_id: '{{ net }}'

--- a/tests/integration/targets/meraki_webhook_payload_template/tasks/tests.yml
+++ b/tests/integration/targets/meraki_webhook_payload_template/tasks/tests.yml
@@ -201,7 +201,7 @@
   - name: Assert name is required when creating/updating/deleting a template
     ansible.builtin.assert:
       that:
-        - 'error_no_body.msg == "name is a required parameter"'
+        - 'error_no_name.msg == "name is a required parameter"'
 
   - name: Test headers args
     cisco.meraki.meraki_webhook_payload_template:
@@ -219,7 +219,7 @@
   - name: Assert headers args are there
     ansible.builtin.assert:
       that:
-        - 'error_no_body.msg == "template in header must be a string"'
+        - 'header_args.msg == "template in header must be a string"'
 
   ############################################################################
   # Tear down starts here

--- a/tests/integration/targets/meraki_webhook_payload_template/tasks/tests.yml
+++ b/tests/integration/targets/meraki_webhook_payload_template/tasks/tests.yml
@@ -1,5 +1,4 @@
 # Test code for the Meraki modules
-
 # Copyright: (c) 2022, Joshua Coronado (@joshuajcoronado) <joshua@coronado.io>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 ---
@@ -222,9 +221,9 @@
       that:
         - 'error_no_body.msg == "template in header must be a string"'
 
-############################################################################
-# Tear down starts here
-############################################################################
+  ############################################################################
+  # Tear down starts here
+  ############################################################################
   always:
 
     - name: Delete wireless network


### PR DESCRIPTION


This module allows users to [manage webhook payload templates](https://developer.cisco.com/meraki/api-latest/#!delete-network-webhooks-payload-template) using the /networks/{networkId}/webhooks/payloadTemplates/ API.

I am unable to run integration tests, so I can't verify that I got every base covered.

```- name: Create payload template
  meraki_webhook_payload_template:
    auth_key: abc12345
    org_name: YourOrg
    state: query
    name: TestTemplate
    body: Testbody
    headers:
        - name: testheader
          template: testheadertemplate
  delegate_to: localhost
```