### PR TITLE
Fix meraki_webhook_payload_template update to support checkmode

### DIFF
--- a/changelogs/fragments/bugfixes-meraki_webhook_payload_template.yml
+++ b/changelogs/fragments/bugfixes-meraki_webhook_payload_template.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix checkmode on merak webhook payload template update
+  


### PR DESCRIPTION
- generate diffs in `meraki_webhook_payload_template` when updating a template
- When running in `check_mode`, fix function to NOT actually update the template