### PR TITLE
Resolve meraki webhook fail when none defined

### DIFF
--- a/changelogs/fragments/433_Resolve_meraki_webhook_fail_when_none_defined.yml
+++ b/changelogs/fragments/433_Resolve_meraki_webhook_fail_when_none_defined.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Resolved an issue where an empty response from the API triggered an exception in module meraki_webhook (https://github.com/CiscoDevNet/ansible-meraki/issues/433)

--- a/changelogs/fragments/Resolve_meraki_webhook_fail_when_none_defined.yml
+++ b/changelogs/fragments/Resolve_meraki_webhook_fail_when_none_defined.yml
@@ -1,2 +1,0 @@
-bugfix:
-  - Resolved an issue where an empty response from the API triggered an exception in module meraki_webhook

--- a/changelogs/fragments/Resolve_meraki_webhook_fail_when_none_defined.yml
+++ b/changelogs/fragments/Resolve_meraki_webhook_fail_when_none_defined.yml
@@ -1,0 +1,2 @@
+bugfix:
+  - Resolved an issue where an empty response from the API triggered an exception in module meraki_webhook

--- a/plugins/modules/meraki_webhook.py
+++ b/plugins/modules/meraki_webhook.py
@@ -210,13 +210,13 @@ def sanitize_no_log_values(meraki):
     except KeyError:
         pass
     try:
-        i=0
+        i = 0
         while i < len(meraki.result["data"]):
-          meraki.result["data"][i][
-              "shared_secret"
-          ] = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
-          i += 1
-          
+            meraki.result["data"][i][
+                "shared_secret"
+            ] = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+            i += 1
+
     except KeyError:
         pass
     try:

--- a/plugins/modules/meraki_webhook.py
+++ b/plugins/modules/meraki_webhook.py
@@ -210,9 +210,13 @@ def sanitize_no_log_values(meraki):
     except KeyError:
         pass
     try:
-        meraki.result["data"][0][
-            "shared_secret"
-        ] = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+        i=0
+        while i < len(meraki.result["data"]):
+          meraki.result["data"][i][
+              "shared_secret"
+          ] = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+          i += 1
+          
     except KeyError:
         pass
     try:

--- a/plugins/modules/meraki_webhook.py
+++ b/plugins/modules/meraki_webhook.py
@@ -210,14 +210,11 @@ def sanitize_no_log_values(meraki):
     except KeyError:
         pass
     try:
-        i = 0
-        while i < len(meraki.result["data"]):
-            meraki.result["data"][i][
+        for i in meraki.result['data']:
+            i[
                 "shared_secret"
             ] = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
-            i += 1
-
-    except KeyError:
+    except (KeyError, TypeError):
         pass
     try:
         meraki.result["data"]["shared_secret"] = "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"

--- a/tests/integration/targets/meraki_webhook/tasks/tests.yml
+++ b/tests/integration/targets/meraki_webhook/tasks/tests.yml
@@ -17,6 +17,22 @@
       net_name: '{{test_net_name}}'
       type: appliance
 
+  - name: Query for any webhooks expecting None
+    meraki_webhook:
+      auth_key: '{{auth_key}}'
+      state: query
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+    register: query_none
+
+  - debug:
+      var: query_none
+    
+  - assert:
+      that:
+        - query_none is not changed
+        - query_none.data[0] is not defined
+
   - name: Create webhook with check mode
     meraki_webhook:
       auth_key: '{{auth_key}}'

--- a/tests/integration/targets/meraki_webhook/tasks/tests.yml
+++ b/tests/integration/targets/meraki_webhook/tasks/tests.yml
@@ -75,6 +75,23 @@
   - set_fact:
       webhook_id: '{{create_one.data.id}}'
 
+  - name: Query all webhooks expecting 1
+    meraki_webhook:
+      auth_key: '{{auth_key}}'
+      state: query
+      org_name: '{{test_org_name}}'
+      net_name: '{{test_net_name}}'
+    register: query_one
+
+  - debug:
+      var: query_one
+
+  - assert:
+      that:
+        - query_one.data is defined
+        - query_one.data[0] is defined
+        - query_one.data[1] is not defined
+
   - name: Query one webhook
     meraki_webhook:
       auth_key: '{{auth_key}}'


### PR DESCRIPTION
Resolves issue #433

Original Issue report concerned meraki_webhook failing when a query returns a list with no entries.

PR adds test coverage for the observed issue, and makes ```sanitize_no_log_values``` work with lists of any length. 

sanity and integration tests passed.