### PR TITLE
Resolve meraki network constraints status pages

### DIFF
--- a/changelogs/fragments/Resolve_local_and_remote_status_pages_constraint.yml
+++ b/changelogs/fragments/Resolve_local_and_remote_status_pages_constraint.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Corrects constraints applied to local and remote status page settings to align with API behaviour (https://github.com/CiscoDevNet/ansible-meraki/issues/437)

--- a/plugins/modules/meraki_network.py
+++ b/plugins/modules/meraki_network.py
@@ -300,8 +300,8 @@ def main():
                 msg="The parameter 'enable_vlans' requires 'net_name' or 'net_id' to be specified"
             )
     if (
-        meraki.params["local_status_page_enabled"] is True
-        and meraki.params["remote_status_page_enabled"] is False
+        meraki.params["local_status_page_enabled"] is False
+        and meraki.params["remote_status_page_enabled"] is True
     ):
         meraki.fail_json(
             msg="local_status_page_enabled must be true when setting remote_status_page_enabled"

--- a/plugins/modules/meraki_network_settings.py
+++ b/plugins/modules/meraki_network_settings.py
@@ -286,8 +286,8 @@ def main():
     if meraki.params["net_name"] and meraki.params["net_id"]:
         meraki.fail_json(msg="net_name and net_id are mutually exclusive")
     if (
-        meraki.params["local_status_page_enabled"] is True
-        and meraki.params["remote_status_page_enabled"] is False
+        meraki.params["local_status_page_enabled"] is False
+        and meraki.params["remote_status_page_enabled"] is True
     ):
         meraki.fail_json(
             msg="local_status_page_enabled must be true when setting remote_status_page_enabled"

--- a/tests/integration/targets/meraki_network/tasks/main.yml
+++ b/tests/integration/targets/meraki_network/tasks/main.yml
@@ -266,7 +266,24 @@
       that:
         - create_net_combined.data.product_types | length > 1
 
-  - name: Test status pages are mutually exclusive when on
+  - name: Test status pages - local disabled remote disabled
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: IntTestNetworkCombined
+      local_status_page_enabled: no
+      remote_status_page_enabled: no
+    delegate_to: localhost
+    register: status_pages_1
+    
+  - assert:
+      that:
+        - status_pages_1.changed == True
+        - status_pages_1['data']['local_status_page_enabled'] == False
+        - status_pages_1['data']['remote_status_page_enabled'] == False
+
+  - name: Test status pages - local enabled remote disabled
     meraki_network:
       auth_key: '{{ auth_key }}'
       state: present
@@ -275,12 +292,48 @@
       local_status_page_enabled: yes
       remote_status_page_enabled: no
     delegate_to: localhost
-    register: status_exclusivity
+    register: status_pages_2
+    
+  - assert:
+      that:
+        - status_pages_2.changed == True
+        - status_pages_2['data']['local_status_page_enabled'] == True
+        - status_pages_2['data']['remote_status_page_enabled'] == False
+
+  - name: Test status pages - local enabled remote enabled
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: IntTestNetworkCombined
+      local_status_page_enabled: yes
+      remote_status_page_enabled: yes
+    delegate_to: localhost
+    register: status_pages_3
+    
+  - assert:
+      that:
+        - status_pages_3.changed == True
+        - status_pages_3['data']['local_status_page_enabled'] == True
+        - status_pages_3['data']['remote_status_page_enabled'] == True
+
+  
+  - name: Test status pages - local disabled remote enabled - expected to fail
+    meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: IntTestNetworkCombined
+      local_status_page_enabled: no
+      remote_status_page_enabled: yes
+    delegate_to: localhost
+    register: status_pages_4
     ignore_errors: yes
 
   - assert:
       that:
-        - '"must be true when setting" in status_exclusivity.msg'
+        - status_pages_4.changed == False
+        - '"must be true when setting" in status_pages_4.msg'
 
   - name: Create network with one tag
     meraki_network:
@@ -360,7 +413,7 @@
         - create_net_modified_idempotent.changed == False
         - create_net_modified_idempotent.data is defined
 
-  - name: Query network settings
+  - name: Query templated network settings
     meraki_network:
       auth_key: '{{auth_key}}'
       state: query

--- a/tests/integration/targets/meraki_network_settings/tasks/main.yml
+++ b/tests/integration/targets/meraki_network_settings/tasks/main.yml
@@ -208,6 +208,79 @@
         - sec_port_idempotent.data is defined
         - sec_port_idempotent.data.secure_port.enabled == true
 
+  - name: Test status pages - local disabled remote disabled
+    cisco.meraki.meraki_network_settings:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: NetworkSettingsTestNet
+      local_status_page_enabled: no
+      remote_status_page_enabled: no
+    delegate_to: localhost
+    register: status_pages_1
+    
+  - name: Assert status pages - local disabled remote disabled
+    ansible.builtin.assert:
+      that:
+        - status_pages_1.changed == True
+        - status_pages_1['data']['local_status_page_enabled'] == False
+        - status_pages_1['data']['remote_status_page_enabled'] == False
+
+  - name: Test status pages - local enabled remote disabled
+    cisco.meraki.meraki_network_settings:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: NetworkSettingsTestNet
+      local_status_page_enabled: yes
+      remote_status_page_enabled: no
+    delegate_to: localhost
+    register: status_pages_2
+    
+  - name: Assert status pages - local enabled remote disabled
+    ansible.builtin.assert:
+      that:
+        - status_pages_2.changed == True
+        - status_pages_2['data']['local_status_page_enabled'] == True
+        - status_pages_2['data']['remote_status_page_enabled'] == False
+
+  - name: Test status pages - local enabled remote enabled
+    cisco.meraki.meraki_network_settings:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: NetworkSettingsTestNet
+      local_status_page_enabled: yes
+      remote_status_page_enabled: yes
+    delegate_to: localhost
+    register: status_pages_3
+    
+  - name: Assert status pages - local enabled remote enabled
+    ansible.builtin.assert:
+      that:
+        - status_pages_3.changed == True
+        - status_pages_3['data']['local_status_page_enabled'] == True
+        - status_pages_3['data']['remote_status_page_enabled'] == True
+
+  
+  - name: Test status pages - local disabled remote enabled - expected to fail
+    cisco.meraki.meraki_network_settings:
+      auth_key: '{{ auth_key }}'
+      state: present
+      org_name: '{{test_org_name}}'
+      net_name: NetworkSettingsTestNet
+      local_status_page_enabled: no
+      remote_status_page_enabled: yes
+    delegate_to: localhost
+    register: status_pages_4
+    ignore_errors: yes
+
+  - name: Assert status pages - local disabled remote enabled
+    ansible.builtin.assert:
+      that:
+        - status_pages_4.changed == False
+        - '"must be true when setting" in status_pages_4.msg'
+
 #############################################################################
 # Tear down starts here
 #############################################################################


### PR DESCRIPTION
Resolves #437; changes to both meraki_network and meraki_network_settings modules to correct the behaviour in line with the API. Added additional test coverage for the local and remote status pages.

integration and sanity tests passed locally.