### PR TITLE
Resolve meraki network query by id returns empty data object

### DIFF
--- a/changelogs/fragments/Resolve_meraki_network_query_by_ID_returns_empty_data_object.yml
+++ b/changelogs/fragments/Resolve_meraki_network_query_by_ID_returns_empty_data_object.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Enables meraki_network query by net_id (https://github.com/CiscoDevNet/ansible-meraki/issues/441)

--- a/plugins/modules/meraki_network.py
+++ b/plugins/modules/meraki_network.py
@@ -359,7 +359,7 @@ def main():
                 meraki.exit_json(**meraki.result)
             else:
                 meraki.result["data"] = meraki.get_net(
-                    meraki.params["org_name"], meraki.params["net_name"], data=nets
+                    meraki.params["org_name"], net_name=meraki.params["net_name"], data=nets, net_id=meraki.params["net_id"],
                 )
                 meraki.exit_json(**meraki.result)
     elif meraki.params["state"] == "present":

--- a/tests/integration/targets/meraki_network/tasks/main.yml
+++ b/tests/integration/targets/meraki_network/tasks/main.yml
@@ -453,10 +453,33 @@
     delegate_to: localhost
     register: net_query_one
 
-  - name: Query assertions
+  - name: Query one network - assert
     assert:
       that:
         - 'net_query_one.data.name == "IntTestNetworkSwitch"'
+        - 'query_config_template.data.name == "{{ test_template_name }}"'
+
+  - name: Set net_id
+    ansible.builtin.set_fact:
+      net_id: "{{ net_query_one.data.id }}"
+
+  - name: Query one network by ID
+    cisco.meraki.meraki_network:
+      auth_key: '{{ auth_key }}'
+      state: query
+      org_name: '{{test_org_name}}'
+      net_id: "{{ net_id}}"
+    delegate_to: localhost
+    register: net_query_one_id
+
+  - name: Query one network by ID - debug
+    ansible.builtin.debug:
+      var: net_query_one_id
+
+  - name: Query one network by ID - assert
+    ansible.builtin.assert:
+      that:
+        - 'net_query_one_id.data.name == "IntTestNetworkSwitch"'
         - 'query_config_template.data.name == "{{ test_template_name }}"'
 
 #############################################################################


### PR DESCRIPTION
Resolves #441 meraki_network query by ID returns empty data object

- adds test coverage for meraki_network query by net_id
- adds net_id to the meraki_network query call