### PR TITLE
increase access speed attribute is needed when setting access policy type Hybrid Auth 

### DIFF
--- a/changelogs/fragments/446-ms_access_policy.yml
+++ b/changelogs/fragments/446-ms_access_policy.yml
@@ -1,2 +1,2 @@
-major:
+breaking_changes:
   - ms_access_policy module, when setting access policy type as Hybrid Authentication needs increaseAccessSpeed attribute to be set

--- a/changelogs/fragments/ms_access_policy.yml
+++ b/changelogs/fragments/ms_access_policy.yml
@@ -1,0 +1,2 @@
+major:
+  - ms_access_policy module, when setting access policy type as Hybrid Authentication needs increaseAccessSpeed attribute to be set

--- a/plugins/modules/meraki_ms_access_policies.py
+++ b/plugins/modules/meraki_ms_access_policies.py
@@ -72,7 +72,7 @@ options:
         description:
         - Required if access_policy_type is set to 'Hybrid Authentication'
         type: bool
-        default: None
+        default: False
     radius_servers:
         description:
         - List of RADIUS servers.
@@ -348,7 +348,7 @@ def main():
             ],
         ),
         systems_management_enrollment=dict(type="bool", default=False),
-        increase_access_speed=dict(type="bool"),
+        increase_access_speed=dict(type="bool", default=False),
         radius_servers=dict(
             type="list", default=None, elements="dict", options=radius_arg_spec
         ),

--- a/plugins/modules/meraki_ms_access_policies.py
+++ b/plugins/modules/meraki_ms_access_policies.py
@@ -72,7 +72,7 @@ options:
         description:
         - Required if access_policy_type is set to 'Hybrid Authentication'
         type: bool
-        default: False
+        default: None
     radius_servers:
         description:
         - List of RADIUS servers.
@@ -477,7 +477,7 @@ def main():
                 meraki.fail_json(msg="Increase Access Speed attribute only takes boolean value")
         except NameError:
             meraki.fail_json(msg="Increase Access Speed attribute needs to be defined when setting access policy type as Hybrid Authentication")
-            
+
     if meraki.params["state"] == "query":
         if meraki.params["number"]:
             path = meraki.construct_path(

--- a/plugins/modules/meraki_ms_access_policies.py
+++ b/plugins/modules/meraki_ms_access_policies.py
@@ -293,7 +293,6 @@ data:
 """
 
 from ansible.module_utils.basic import AnsibleModule, json
-from ansible.module_utils.common.dict_transformations import recursive_diff
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import (
     MerakiModule,
     meraki_argument_spec,

--- a/plugins/modules/meraki_ms_access_policies.py
+++ b/plugins/modules/meraki_ms_access_policies.py
@@ -468,7 +468,16 @@ def main():
             "systems_management_enrollment"
         ],
     }
-
+    # Execute check for argument completeness
+    if meraki.params["access_policy_type"] == "Hybrid authentication":
+        try:
+            if isinstance(meraki.params["increase_access_speed"], bool):
+                pass
+            else:
+                meraki.fail_json(msg="Increase Access Speed attribute only takes boolean value")
+        except NameError:
+            meraki.fail_json(msg="Increase Access Speed attribute needs to be defined when setting access policy type as Hybrid Authentication")
+            
     if meraki.params["state"] == "query":
         if meraki.params["number"]:
             path = meraki.construct_path(

--- a/plugins/modules/meraki_ms_access_policies.py
+++ b/plugins/modules/meraki_ms_access_policies.py
@@ -68,6 +68,11 @@ options:
         - Set if the Systems Management Enrollemnt is enabled or disabled
         type: bool
         default: False
+    increase_access_speed:
+        description:
+        - Required if access_policy_type is set to 'Hybrid Authentication'
+        type: bool
+        default: False
     radius_servers:
         description:
         - List of RADIUS servers.
@@ -343,6 +348,7 @@ def main():
             ],
         ),
         systems_management_enrollment=dict(type="bool", default=False),
+        increase_access_speed=dict(type="bool"),
         radius_servers=dict(
             type="list", default=None, elements="dict", options=radius_arg_spec
         ),
@@ -452,6 +458,7 @@ def main():
         "radiusCoaSupportEnabled": meraki.params["radius_coa_enabled"],
         "hostMode": meraki.params["host_mode"],
         "accessPolicyType": meraki.params["access_policy_type"],
+        "increaseAccessSpeed": meraki.params["increase_access_speed"],
         "guestVlanId": meraki.params["guest_vlan"],
         "voiceVlanClients": meraki.params["voice_vlan_clients"],
         "urlRedirectWalledGardenEnabled": False,

--- a/plugins/modules/meraki_ms_access_policies.py
+++ b/plugins/modules/meraki_ms_access_policies.py
@@ -293,6 +293,7 @@ data:
 """
 
 from ansible.module_utils.basic import AnsibleModule, json
+from ansible.module_utils.common.dict_transformations import recursive_diff
 from ansible_collections.cisco.meraki.plugins.module_utils.network.meraki.meraki import (
     MerakiModule,
     meraki_argument_spec,
@@ -457,8 +458,8 @@ def main():
         },
         "radiusCoaSupportEnabled": meraki.params["radius_coa_enabled"],
         "hostMode": meraki.params["host_mode"],
-        "accessPolicyType": meraki.params["access_policy_type"],
         "increaseAccessSpeed": meraki.params["increase_access_speed"],
+        "accessPolicyType": meraki.params["access_policy_type"],
         "guestVlanId": meraki.params["guest_vlan"],
         "voiceVlanClients": meraki.params["voice_vlan_clients"],
         "urlRedirectWalledGardenEnabled": False,
@@ -470,13 +471,10 @@ def main():
     }
     # Execute check for argument completeness
     if meraki.params["access_policy_type"] == "Hybrid authentication":
-        try:
-            if isinstance(meraki.params["increase_access_speed"], bool):
-                pass
-            else:
-                meraki.fail_json(msg="Increase Access Speed attribute only takes boolean value")
-        except NameError:
-            meraki.fail_json(msg="Increase Access Speed attribute needs to be defined when setting access policy type as Hybrid Authentication")
+        if isinstance(meraki.params["increase_access_speed"], bool):
+            pass
+        else:
+            meraki.fail_json(msg="Increase Access Speed attribute only takes boolean value")
 
     if meraki.params["state"] == "query":
         if meraki.params["number"]:

--- a/tests/integration/targets/meraki_ms_access_policies/tasks/main.yml
+++ b/tests/integration/targets/meraki_ms_access_policies/tasks/main.yml
@@ -560,11 +560,11 @@
       delegate_to: localhost
       register: delete_access_policy
 
+#Hybrid Authentication method requires increaseAccessSpeed attribute of API to be set
 - name: Testing meraki_ms_access_policies with auth_mode as "my RADIUS server" and access_policy_type "Hybrid Authentication
-  #Hybrid Authentication method requires increaseAccessSpeed attribute of API to be set
   block:
     - name: Create a access policy meraki_ms_access_policies with auth_mode as "my RADIUS server" and access_policy_type "Hybrid Authentication"
-      meraki_ms_access_policies:
+      cisco.meraki.meraki_ms_access_policies:
         state: present
         org_name: "{{ org_name }}"
         use_proxy: True
@@ -603,7 +603,7 @@
       ansible.builtin.assert:
         that:
           - create_access_policy_my_radius_server_bybrid is changed
-          - query_one.data.increase_access_speed
+          - query_one.data.increase_access_speed is true
 
   always:
     - name: Delete access policy

--- a/tests/integration/targets/meraki_ms_access_policies/tasks/main.yml
+++ b/tests/integration/targets/meraki_ms_access_policies/tasks/main.yml
@@ -559,3 +559,59 @@
         net_name: "{{ test_net_name }}"
       delegate_to: localhost
       register: delete_access_policy
+
+- name: Testing meraki_ms_access_policies with auth_mode as "my RADIUS server" and access_policy_type "Hybrid Authentication
+  #Hybrid Authentication method requires increaseAccessSpeed attribute of API to be set
+  block:
+    - name: Create a access policy meraki_ms_access_policies with auth_mode as "my RADIUS server" and access_policy_type "Hybrid Authentication"
+      meraki_ms_access_policies:
+        state: present
+        org_name: "{{ org_name }}"
+        use_proxy: True
+        auth_key: "{{ auth_key }}"
+        net_name: "{{ network_name }}"
+        access_policy_type: "Hybrid authentication"
+        name: "RADIUS"
+        radius_servers:
+        - host: "10.0.0.1"
+          port: 1812
+          secret: "secret123"
+        - host: "10.0.0.2"
+          port: 1812
+          secret: "secret123"
+        radius_testing: true
+        radius_coa_enabled: true
+        radius_accounting_enabled: false
+        host_mode: "Multi-Auth"
+        auth_method: "my RADIUS server"
+        voice_vlan_clients: true
+        increase_access_speed: true
+      delegate_to: localhost
+      register: create_access_policy_my_radius_server_hybrid
+
+    - name: Query one access policy
+      cisco.meraki.meraki_ms_access_policies:
+        auth_key: "{{ auth_key }}"
+        state: query
+        org_name: "{{ test_org_name }}"
+        net_name: "{{ test_net_name }}"
+        number: 1
+      delegate_to: localhost
+      register: query_one
+
+    - name: Checking if the query one access policy returns right name of policy
+      ansible.builtin.assert:
+        that:
+          - create_access_policy_my_radius_server_bybrid is changed
+          - query_one.data.increase_access_speed
+
+  always:
+    - name: Delete access policy
+      cisco.meraki.meraki_ms_access_policies:
+        auth_key: "{{ auth_key }}"
+        state: absent
+        number: 1
+        org_name: "{{ test_org_name }}"
+        net_name: "{{ test_net_name }}"
+      delegate_to: localhost
+      register: delete_access_policy

--- a/tests/integration/targets/meraki_ms_access_policies/tasks/main.yml
+++ b/tests/integration/targets/meraki_ms_access_policies/tasks/main.yml
@@ -560,25 +560,24 @@
       delegate_to: localhost
       register: delete_access_policy
 
-#Hybrid Authentication method requires increaseAccessSpeed attribute of API to be set
+# Hybrid Authentication method requires increaseAccessSpeed attribute of API to be set
 - name: Testing meraki_ms_access_policies with auth_mode as "my RADIUS server" and access_policy_type "Hybrid Authentication
   block:
     - name: Create a access policy meraki_ms_access_policies with auth_mode as "my RADIUS server" and access_policy_type "Hybrid Authentication"
       cisco.meraki.meraki_ms_access_policies:
         state: present
         org_name: "{{ org_name }}"
-        use_proxy: True
         auth_key: "{{ auth_key }}"
         net_name: "{{ network_name }}"
         access_policy_type: "Hybrid authentication"
         name: "RADIUS"
         radius_servers:
-        - host: "10.0.0.1"
-          port: 1812
-          secret: "secret123"
-        - host: "10.0.0.2"
-          port: 1812
-          secret: "secret123"
+          - host: "10.0.0.1"
+            port: 1812
+            secret: "secret123"
+          - host: "10.0.0.2"
+            port: 1812
+            secret: "secret123"
         radius_testing: true
         radius_coa_enabled: true
         radius_accounting_enabled: false


### PR DESCRIPTION
increase access speed attribute is needed when setting access policy type Hybrid Authentication 
This may be a new feature and the Meraki side doesn't automatically assumes this to be true/false therfore erroring the API call 